### PR TITLE
refactor(html-templates): convert script tags to reusable fragments

### DIFF
--- a/src/main/resources/templates/checkin/create.html
+++ b/src/main/resources/templates/checkin/create.html
@@ -1,109 +1,84 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
 
-<body layout="layout-secured">
-<fbauth-element>
-    <div layout="layout-sidebar">
-        <header th:replace="~{fragments/header :: header(${activePage})}"></header>
-        <div class="sidebar-grid-area">
-            <nav class="navbar navbar-expand-lg navbar-light">
-                <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item"><a class="nav-link active" aria-current="page" href="/checkin/">Checkin
-                            Home</a></li>
-                    </ul>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link active" aria-current="page" href="/checkin/">Checkin
+                                    Home</a></li>
+                            </ul>
+                        </div>
+                    </nav>
                 </div>
-            </nav>
-        </div>
-        <div class="ga-content-main">
-            <main>
-                <form method="post" action="/checkin/create">
-                    <h1>Create Checkin</h1>
-                    <input name="uid" type="hidden" id="uid"/>
-                    <div class="mb-3">
-                        <label class="form-label">Next Assignment:</label>
-                        <input class="form-control" type="number" th:field="${checkin.nextAssignment}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Blockers:</label>
-                        <input type="checkbox" th:field="${checkin.blockers}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Blocker Description:</label>
-                        <input type="text" th:field="${checkin.blockerDescription}"/>
-                    </div>
-                    <label class="form-label">Live Coding Session?</label>
-                    <input type="checkbox" id="toggleCheckbox" name="toggleCheckbox"><br><br>
-                    <div id="controlsToToggle" style="display: none;">
-                        <div class="mb-3">
-                            <label class="form-label">Box Ready for Live Coding?:</label>
-                            <input type="checkbox" th:field="${checkin.isSetUp}"/>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Are You Available/willing to Code?:</label>
-                            <input type="checkbox" th:field="${checkin.available}"/>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Role:</label>
-                            <select class="form-control" th:field="*{checkin.role}">
-                                <option th:each="role : ${roleList}" th:value="${role}"
-                                        th:text="${#strings.capitalize(role.toString())}">
-                                </option>
-                            </select>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Coding Type:</label>
-                            <select class="form-control" th:field="*{checkin.codingType}">
-                                <option th:each="codingType : ${codingType}" th:value="${codingType}"
-                                        th:text="${#strings.capitalize(codingType.toString())}">
-                                </option>
-                            </select>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Issue Number:</label>
-                            <input class="form-control" type="number" th:field="${checkin.issueNumber}"/>
-                        </div>
-                    </div>
-                    <div class="mb-3">
-                        <input class="form-control btn btn-primary" type="submit" value="Create"/>
-                    </div>
-                    <div class="mb-3">
-                        <input class="form-control btn btn-secondary" type="" value="Start Time/End Time"/>
-                    </div>
-                </form>
-            </main>
-        </div>
-        <div th:replace="~{fragments/footer :: footer}"></div>
-    </div>
-</fbauth-element>
-<script>
-    document.getElementById("toggleCheckbox").addEventListener("change", function () {
-        var controls = document.getElementById("controlsToToggle");
-        if (this.checked) {
-            controls.style.display = "block";
-        } else {
-            controls.style.display = "none";
-        }
-    });
+                <div class="ga-content-main">
+                    <main>
+                        <form method="post" action="/checkin/create">
+                            <h1>Create Checkin</h1>
+                            <input name="uid" type="hidden" id="uid"/>
+                            <div class="mb-3">
+                                <label class="form-label">Next Assignment:</label>
+                                <input class="form-control" type="number" th:field="${checkin.nextAssignment}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Blockers:</label>
+                                <input type="checkbox" th:field="${checkin.blockers}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Blocker Description:</label>
+                                <input type="text" th:field="${checkin.blockerDescription}"/>
+                            </div>
+                            <label class="form-label">Live Coding Session?</label>
+                            <input type="checkbox" id="toggleCheckbox" name="toggleCheckbox"><br><br>
+                            <div id="controlsToToggle" style="display: none;">
+                                <div class="mb-3">
+                                    <label class="form-label">Box Ready for Live Coding?:</label>
+                                    <input type="checkbox" th:field="${checkin.isSetUp}"/>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Are You Available/willing to Code?:</label>
+                                    <input type="checkbox" th:field="${checkin.available}"/>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Role:</label>
+                                    <select class="form-control" th:field="*{checkin.role}">
+                                        <option th:each="role : ${roleList}" th:value="${role}"
+                                                th:text="${#strings.capitalize(role.toString())}">
+                                        </option>
+                                    </select>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Coding Type:</label>
+                                    <select class="form-control" th:field="*{checkin.codingType}">
+                                        <option th:each="codingType : ${codingType}" th:value="${codingType}"
+                                                th:text="${#strings.capitalize(codingType.toString())}">
+                                        </option>
+                                    </select>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Issue Number:</label>
+                                    <input class="form-control" type="number" th:field="${checkin.issueNumber}"/>
+                                </div>
+                            </div>
+                            <div class="mb-3">
+                                <input class="form-control btn btn-primary" type="submit" value="Create"/>
+                            </div>
+                            <div class="mb-3">
+                                <input class="form-control btn btn-secondary" type="" value="Start Time/End Time"/>
+                            </div>
+                        </form>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
 
-    const fbauth = document.querySelector('fbauth-element');
-    const uid = document.getElementById('uid');
-    const displayName = document.getElementById('display-name');
-    fbauth.addEventListener('user-changed', (event) => {
-        const {newValue} = event.detail;
-        if (newValue) {
-            uid.value = newValue.uid;
-        } else {
-            uid.value = '';
-        }
-        if (newValue) {
-            displayName.value = newValue.displayName;
-        } else {
-            displayName.value = '';
-        }
-    });
-</script>
-</body>
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 
 </html>

--- a/src/main/resources/templates/checkin/read.html
+++ b/src/main/resources/templates/checkin/read.html
@@ -1,85 +1,65 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
 
-<body layout="layout-secured">
-<fbauth-element>
-    <div layout="layout-sidebar">
-        <header th:replace="~{fragments/header :: header(${activePage})}"></header>
-        <div class="sidebar-grid-area">
-            <nav class="navbar navbar-expand-lg navbar-light">
-                <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item"><a class="nav-link" href="/checkin/create">Create Checkin</a></li>
-                    </ul>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link" href="/checkin/create">Create Checkin</a></li>
+                            </ul>
+                        </div>
+                    </nav>
                 </div>
-            </nav>
-        </div>
-        <div class="ga-content-main">
-            <main>
-                <table class="table">
-                    <thead>
-                    <tr>
-                        <th scope="col">Next Assignment:</th>
-                        <th scope="col">Blockers:</th>
-                        <th scope="col">Blocker Description:</th>
-                        <th scope="col">Box Ready for Live Coding?:</th>
-                        <th scope="col">Are You Available/willing to Code?:</th>
-                        <th scope="col">Role:</th>
-                        <th scope="col">Coding Type:</th>
-                        <th scope="col">Issue Number:</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr th:each="checkin: ${checkins}">
-                        <td><span th:text="${checkin.nextAssignment}"></span></td>
-                        <td><span th:text="${checkin.blockers}"></span></td>
-                        <td><span th:text="${checkin.blockerDescription}"></span></td>
-                        <td><span th:text="${checkin.isSetUp}"></span></td>
-                        <td><span th:text="${checkin.available}"></span></td>
-                        <td><span th:text="${checkin.role}"></span></td>
-                        <td><span th:text="${checkin.codingType}"></span></td>
-                        <td><span th:text="${checkin.issueNumber}"></span></td>
-                        <td>
-                            <a th:href="@{/checkin/update/{checkinId}(checkinId=${checkin.id})}">
+                <div class="ga-content-main">
+                    <main>
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Next Assignment:</th>
+                                    <th scope="col">Blockers:</th>
+                                    <th scope="col">Blocker Description:</th>
+                                    <th scope="col">Box Ready for Live Coding?:</th>
+                                    <th scope="col">Are You Available/willing to Code?:</th>
+                                    <th scope="col">Role:</th>
+                                    <th scope="col">Coding Type:</th>
+                                    <th scope="col">Issue Number:</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr th:each="checkin: ${checkins}">
+                                    <td><span th:text="${checkin.nextAssignment}"></span></td>
+                                    <td><span th:text="${checkin.blockers}"></span></td>
+                                    <td><span th:text="${checkin.blockerDescription}"></span></td>
+                                    <td><span th:text="${checkin.isSetUp}"></span></td>
+                                    <td><span th:text="${checkin.available}"></span></td>
+                                    <td><span th:text="${checkin.role}"></span></td>
+                                    <td><span th:text="${checkin.codingType}"></span></td>
+                                    <td><span th:text="${checkin.issueNumber}"></span></td>
+                                    <td>
+                                        <a th:href="@{/checkin/update/{checkinId}(checkinId=${checkin.id})}">
 									<span>
                                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                              fill="currentColor" class="bi bi-view-list" viewBox="0 0 16 16">
                                             <path d="M3 4.5h10a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2zm0 1a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1H3zM1 2a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 2zm0 12a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 14z"/>
                                         </svg>
                                     </span>
-                            </a>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </main>
-        </div>
-        <div th:replace="~{fragments/footer :: footer}"></div>
-    </div>
-</fbauth-element>
-<script>
-    const fbauth = document.querySelector('fbauth-element');
-    const uid = document.getElementById('uid');
-    console.log("UID: " + uid);
-    const displayName = document.getElementById('display-name');
-    console.log("Display Name: " + displayName);
-    fbauth.addEventListener('user-changed', (event) => {
-        const {newValue} = event.detail;
-        console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-        if (newValue) {
-            uid.value = newValue.uid;
-        } else {
-            uid.value = '';
-        }
-        if (newValue) {
-            displayName.value = newValue.displayName;
-        } else {
-            displayName.value = '';
-        }
-    });
-</script>
-</body>
+                                        </a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 </html>
 
 

--- a/src/main/resources/templates/checkin/update.html
+++ b/src/main/resources/templates/checkin/update.html
@@ -1,122 +1,95 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
 
-<body layout="layout-secured">
-<fbauth-element>
-    <div layout="layout-sidebar">
-        <header th:replace="~{fragments/header :: header(${activePage})}"></header>
-        <div class="sidebar-grid-area">
-            <nav class="navbar navbar-expand-lg navbar-light">
-                <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item"><a class="nav-link active" aria-current="page" href="/checkin/">Checkin Home</a></li>
-                        <li class="nav-item"><a class="nav-link" href="/checkin/create">Create Checkin</a></li>
-                    </ul>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link active" aria-current="page" href="/checkin/">Checkin
+                                    Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="/checkin/create">Create Checkin</a></li>
+                            </ul>
+                        </div>
+                    </nav>
                 </div>
-            </nav>
-        </div>
-        <div class="ga-content-main">
-            <main>
-                <form method="post" action="/checkin/update" class="mb-3">
-                    <input class="form-control" type="hidden" th:field="${checkin.id}"/> <br>
+                <div class="ga-content-main">
+                    <main>
+                        <form method="post" action="/checkin/update" class="mb-3">
+                            <input class="form-control" type="hidden" th:field="${checkin.id}"/> <br>
 
-                    <div class="mb-3">
-                        <label class="form-label">Date:</label>
-                        <input type="text" th:field="${checkin.date}" disabled/>
-                    </div>
+                            <div class="mb-3">
+                                <label class="form-label">Date:</label>
+                                <input type="text" th:field="${checkin.date}" disabled/>
+                            </div>
 
-                    <div class="mb-3">
-                        <label class="form-label">Next Assignment:</label>
-                        <input type="number" th:field="${checkin.nextAssignment}"/>
-                    </div>
+                            <div class="mb-3">
+                                <label class="form-label">Next Assignment:</label>
+                                <input type="number" th:field="${checkin.nextAssignment}"/>
+                            </div>
 
-                    <div class="mb-3">
-                        <label class="form-label">Blockers: </label>
-                        <input type="checkbox" th:field="${checkin.blockers}"/>
-                    </div>
+                            <div class="mb-3">
+                                <label class="form-label">Blockers: </label>
+                                <input type="checkbox" th:field="${checkin.blockers}"/>
+                            </div>
 
-                    <div class="mb-3">
-                        <label class="form-label">Blocker Description:</label>
-                        <input type="text" th:field="${checkin.blockerDescription}"/>
-                    </div>
+                            <div class="mb-3">
+                                <label class="form-label">Blocker Description:</label>
+                                <input type="text" th:field="${checkin.blockerDescription}"/>
+                            </div>
 
-                    <label class="form-label">Live Coding Session?</label>
-                    <input type="checkbox" id="toggleCheckbox" name="toggleCheckbox"><br><br>
-                    <div id="controlsToToggle" style="display: none;">
-                        <div class="mb-3">
-                            <label class="form-label">Box Ready for Live Coding?:</label>
-                            <input type="checkbox" th:field="${checkin.isSetUp}"/>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Are You Available/willing to Code?:</label>
-                            <input type="checkbox" th:field="${checkin.available}"/>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Role:</label>
-                            <select class="form-control" th:field="*{checkin.role}">
-                                <option th:each="role : ${roleList}" th:value="${role}"
-                                        th:text="${#strings.capitalize(role.toString())}">
-                                </option>
-                            </select>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Coding Type:</label>
-                            <select class="form-control" th:field="*{checkin.codingType}">
-                                <option th:each="codingType : ${codingType}" th:value="${codingType}"
-                                        th:text="${#strings.capitalize(codingType.toString())}">
-                                </option>
-                            </select>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Issue Number:</label>
-                            <input class="form-control" type="number" th:field="${checkin.issueNumber}"/>
-                        </div>
-                    </div>
+                            <label class="form-label">Live Coding Session?</label>
+                            <input type="checkbox" id="toggleCheckbox" name="toggleCheckbox"><br><br>
+                            <div id="controlsToToggle" style="display: none;">
+                                <div class="mb-3">
+                                    <label class="form-label">Box Ready for Live Coding?:</label>
+                                    <input type="checkbox" th:field="${checkin.isSetUp}"/>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Are You Available/willing to Code?:</label>
+                                    <input type="checkbox" th:field="${checkin.available}"/>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Role:</label>
+                                    <select class="form-control" th:field="*{checkin.role}">
+                                        <option th:each="role : ${roleList}" th:value="${role}"
+                                                th:text="${#strings.capitalize(role.toString())}">
+                                        </option>
+                                    </select>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Coding Type:</label>
+                                    <select class="form-control" th:field="*{checkin.codingType}">
+                                        <option th:each="codingType : ${codingType}" th:value="${codingType}"
+                                                th:text="${#strings.capitalize(codingType.toString())}">
+                                        </option>
+                                    </select>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Issue Number:</label>
+                                    <input class="form-control" type="number" th:field="${checkin.issueNumber}"/>
+                                </div>
+                            </div>
 
-                    <input class="form-control btn btn-primary mt-3" type="submit" value="Update"/>
-                    <input class="form-control btn btn-secondary" type="" value="Start Time/End Time"/>
-					 <input name="uid" type="hidden" id="uid"/>
-                </form>
-                <form method="post" action="/checkin/delete" class="mb-3">
-                    <input type="hidden" th:field="${checkin.id}"/>
-                    <input class="form-control btn btn-danger" type="submit" value="Delete"/>
-                </form>
-            </main>
-        </div>
-        <div th:replace="~{fragments/footer :: footer}"></div>
-    </div>
-</fbauth-element>
-<script>
-    document.getElementById("toggleCheckbox").addEventListener("change", function () {
-        var controls = document.getElementById("controlsToToggle");
-        if (this.checked) {
-            controls.style.display = "block";
-        } else {
-            controls.style.display = "none";
-        }
-    });
+                            <input class="form-control btn btn-primary mt-3" type="submit" value="Update"/>
+                            <input class="form-control btn btn-secondary" type="" value="Start Time/End Time"/>
+                            <input name="uid" type="hidden" id="uid"/>
+                        </form>
+                        <form method="post" action="/checkin/delete" class="mb-3">
+                            <input type="hidden" th:field="${checkin.id}"/>
+                            <input class="form-control btn btn-danger" type="submit" value="Delete"/>
+                        </form>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
 
-    const fbauth = document.querySelector('fbauth-element');
-    const uid = document.getElementById('uid');
-    console.log("UID: " + uid);
-    const displayName = document.getElementById('display-name');
-    console.log("Display Name: " + displayName);
-    fbauth.addEventListener('user-changed', (event) => {
-        const {newValue} = event.detail;
-        console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-        if (newValue) {
-            uid.value = newValue.uid;
-        } else {
-            uid.value = '';
-        }
-        if (newValue) {
-            displayName.value = newValue.displayName;
-        } else {
-            displayName.value = '';
-        }
-    });
-</script>
-</body>
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 </html>
 

--- a/src/main/resources/templates/foobar/create.html
+++ b/src/main/resources/templates/foobar/create.html
@@ -1,56 +1,41 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
 
-<body layout="layout-secured">
-<fbauth-element>
-    <div layout="layout-sidebar">
-        <header th:replace="~{fragments/header :: header(${activePage})}"></header>
-        <div class="sidebar-grid-area">
-            <nav class="navbar navbar-expand-lg navbar-light">
-                <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item"><a class="nav-link" href="/foobar/create">Create
-                            Foobar</a></li>
-                    </ul>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link" href="/foobar/create">Create
+                                    Foobar</a></li>
+                            </ul>
+                        </div>
+                    </nav>
                 </div>
-            </nav>
-        </div>
-        <div class="ga-content-main">
-            <main>
-                <form method="post" action="/foobar/create">
-                    <h1>Create Foobar</h1>
-                    <div class="mb-3">
-                        <label class="form-label">Name: </label>
-                        <input class="form-control" type="text" id="display-name" th:field="${foobar.name}"/>
-                        <input name="uid" type="hidden" id="uid"/>
-                    </div>
-                    <div class="mb-3">
-                        <input class="form-control btn btn-primary" type="submit" value="Create"/>
-                    </div>
-                </form>
-            </main>
-        </div>
-        <div th:replace="~{fragments/footer :: footer}"></div>
-    </div>
-</fbauth-element>
-<script>
-    const fbauth = document.querySelector('fbauth-element');
-    const uid = document.getElementById('uid');
-    console.log("Foobar/create.html| UID: " + uid);
-    const displayName = document.getElementById('display-name');
-    fbauth.addEventListener('user-changed', (event) => {
-        const {newValue} = event.detail;
-        console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-        if (newValue) {
-            displayName.value = newValue.displayName;
-            uid.value = newValue.uid;
-        } else {
-            displayName.value = '';
-            uid.value = '';
-        }
-    });
-</script>
-</body>
+                <div class="ga-content-main">
+                    <main>
+                        <form method="post" action="/foobar/create">
+                            <h1>Create Foobar</h1>
+                            <div class="mb-3">
+                                <label class="form-label">Name: </label>
+                                <input class="form-control" type="text" id="display-name" th:field="${foobar.name}"/>
+                                <input name="uid" type="hidden" id="uid"/>
+                            </div>
+                            <div class="mb-3">
+                                <input class="form-control btn btn-primary" type="submit" value="Create"/>
+                            </div>
+                        </form>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
+
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 
 </html>

--- a/src/main/resources/templates/foobar/read.html
+++ b/src/main/resources/templates/foobar/read.html
@@ -1,62 +1,47 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
-<body layout="layout-secured">
-<fbauth-element>
-    <div layout="layout-sidebar">
-        <header th:replace="~{fragments/header :: header(${activePage})}"></header>
-        <div class="sidebar-grid-area">
-            <nav class="navbar navbar-expand-lg navbar-light">
-                <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item"><a class="nav-link" href="/foobar/create">Create Foobar</a></li>
-                    </ul>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link" href="/foobar/create">Create Foobar</a></li>
+                            </ul>
+                        </div>
+                    </nav>
                 </div>
-            </nav>
-        </div>
-        <div class="ga-content-main">
-            <main>
-                <table class="table">
-                    <thead>
-                    <tr>
-                        <th scope="col">Name:</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr th:each="foobar: ${foobars}">
-                        <td><span th:text="${foobar.name}"></span></td>
-                        <td><a th:href="@{/foobar/update/{foobarId}(foobarId=${foobar.id})}">
+                <div class="ga-content-main">
+                    <main>
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Name:</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr th:each="foobar: ${foobars}">
+                                    <td><span th:text="${foobar.name}"></span></td>
+                                    <td><a th:href="@{/foobar/update/{foobarId}(foobarId=${foobar.id})}">
 					<span><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                                class="bi bi-view-list" viewBox="0 0 16 16">
   <path d="M3 4.5h10a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2zm0 1a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1H3zM1 2a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 2zm0 12a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 14z"/>
 </svg></span> </a></td>
-                    </tr>
+                                </tr>
 
-                    </tbody>
-                </table>
-            </main>
-        </div>
-        <div th:replace="~{fragments/footer :: footer}"></div>
-    </div>
-</fbauth-element>
-<script>
-    const fbauth = document.querySelector('fbauth-element');
-    const uid = document.getElementById('uid');
-    console.log("Foobar/read.html| UID: " + uid);
-    const displayName = document.getElementById('display-name');
-    fbauth.addEventListener('user-changed', (event) => {
-        const {newValue} = event.detail;
-        console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-        if (newValue) {
-            displayName.value = newValue.displayName;
-            uid.value = newValue.uid;
-        } else {
-            displayName.value = '';
-            uid.value = '';
-        }
-    });
-</script>
-</body>
+                            </tbody>
+                        </table>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
+
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 </html>
 
 

--- a/src/main/resources/templates/foobar/update.html
+++ b/src/main/resources/templates/foobar/update.html
@@ -1,56 +1,42 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
 
-<body layout="layout-secured">
-	<fbauth-element>
-		<div layout="layout-sidebar">
-			<header th:replace="~{fragments/header :: header(${activePage})}"></header>
-			<div class="sidebar-grid-area">
-				<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="collapse navbar-collapse" id="navbarNav">
-						<ul class="navbar-nav">
-							<li class="nav-item"><a class="nav-link active" aria-current="page"
-									href="/foobar/">Foobar Home</a></li>
-							<li class="nav-item"><a class="nav-link" href="/foobar/create">Create Foobar</a>
-							</li>
-						</ul>
-					</div>
-				</nav>
-			</div>
-			<div class="ga-content-main">
-				<main>
-					<form method="post" action="/foobar/update" class="mb-3">
-						<input class="form-control" type="hidden" th:field="${foobar.id}" /> 
-						<label class="form-label">Name: </label> 
-						<input class="form-control" type="text" th:field="${foobar.name}" /> 
-						<input class="form-control btn btn-primary mt-3" type="submit" value="Update" />
-					</form>
-					<form method="post" action="/foobar/delete" class="mb-3">
-						<input type="hidden" th:field="${foobar.id}" />
-						<input class="form-control btn btn-danger" type="submit" value="Delete" />
-					</form>
-				</main>
-			</div>
-			<div th:replace="~{fragments/footer :: footer}"></div>
-		</div>
-	</fbauth-element>
-	<script>
-		const fbauth = document.querySelector('fbauth-element');
-		const uid = document.getElementById('uid');
-		const displayName = document.getElementById('display-name');
-		fbauth.addEventListener('user-changed', (event) => {
-			const { newValue } = event.detail;
-			console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-			if (newValue) {
-				displayName.value = newValue.displayName;
-				uid.value = newValue.uid;
-			} else {
-				displayName.value = '';
-				uid.value = '';
-			}
-		});
-	</script>
-</body>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link active" aria-current="page"
+                                                        href="/foobar/">Foobar Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="/foobar/create">Create Foobar</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </nav>
+                </div>
+                <div class="ga-content-main">
+                    <main>
+                        <form method="post" action="/foobar/update" class="mb-3">
+                            <input class="form-control" type="hidden" th:field="${foobar.id}"/>
+                            <label class="form-label">Name: </label>
+                            <input class="form-control" type="text" th:field="${foobar.name}"/>
+                            <input class="form-control btn btn-primary mt-3" type="submit" value="Update"/>
+                        </form>
+                        <form method="post" action="/foobar/delete" class="mb-3">
+                            <input type="hidden" th:field="${foobar.id}"/>
+                            <input class="form-control btn btn-danger" type="submit" value="Delete"/>
+                        </form>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
+
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 
 </html>

--- a/src/main/resources/templates/fragments/authscript.html
+++ b/src/main/resources/templates/fragments/authscript.html
@@ -1,0 +1,27 @@
+<script>
+    document.getElementById("toggleCheckbox").addEventListener("change", function () {
+        var controls = document.getElementById("controlsToToggle");
+        if (this.checked) {
+            controls.style.display = "block";
+        } else {
+            controls.style.display = "none";
+        }
+    });
+
+    const fbauth = document.querySelector('fbauth-element');
+    const uid = document.getElementById('uid');
+    const displayName = document.getElementById('display-name');
+    fbauth.addEventListener('user-changed', (event) => {
+        const {newValue} = event.detail;
+        if (newValue) {
+            uid.value = newValue.uid;
+        } else {
+            uid.value = '';
+        }
+        if (newValue) {
+            displayName.value = newValue.displayName;
+        } else {
+            displayName.value = '';
+        }
+    });
+</script>

--- a/src/main/resources/templates/student/create.html
+++ b/src/main/resources/templates/student/create.html
@@ -1,96 +1,80 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
 
-<body layout="layout-secured">
-<fbauth-element>
-    <div layout="layout-sidebar">
-        <header th:replace="~{fragments/header :: header(${activePage})}"></header>
-        <div class="sidebar-grid-area">
-            <nav class="navbar navbar-expand-lg navbar-light">
-                <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item"><a class="nav-link active"
-                                                aria-current="page" href="/student/">Student Home</a></li>
-                    </ul>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link active"
+                                                        aria-current="page" href="/student/">Student Home</a></li>
+                            </ul>
+                        </div>
+                    </nav>
                 </div>
-            </nav>
-        </div>
-        <div class="ga-content-main">
-            <main>
-                <form method="post" action="/student/create">
-                    <h1>Create Student</h1>
-                    <input name="uid" type="hidden" id="uid"/>
-                    <div class="mb-3">
-                        <label class="form-label">Name:</label>
-                        <input class="form-control" type="text" id="display-name" th:field="${student.name}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Assignment Number:</label><input
-                            class="form-control" type="text"
-                            th:field="${student.assignmentNum}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Github Handle:</label>
-                        <input class="form-control" type="text" th:field="${student.githubHandle.handle}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">LinkedIn URL:</label>
-                        <input class="form-control" type="text" th:field="${student.linkedIn.url}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">IDE: </label>
-                        <input class="form-control" type="text" th:field="${student.ide}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">YouTube:</label>
-                        <input class="form-control" type="text" th:field="${student.youtube.profile}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Final Project:</label>
-                        <input class="form-control" type="text" th:field="${student.finalProject.title}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Resume:</label>
-                        <input class="form-control" type="text" th:field="${student.resume.resumeFile}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Networking:</label>
-                        <input class="form-control" type="text" th:field="${student.networking.meetups}"/>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Website:</label>
-                        <input class="form-control" type="text" th:field="${student.website.url}"/>
-                    </div>
-                    <div class="mb-3">
-                        <input onfocus="assignUid()" class="form-control btn btn-primary"
-                               type="submit" value="Create"/>
-                    </div>
-                </form>
-            </main>
-        </div>
-        <div th:replace="~{fragments/footer :: footer}"></div>
-    </div>
-</fbauth-element>
-<script>
-    const fbauth = document.querySelector('fbauth-element');
-    const uid = document.getElementById('uid');
-    console.log("UID: " + uid)
-    const displayName = document.getElementById('display-name');
-    console.log("display-name: " + displayName)
-    fbauth.addEventListener('user-changed', (event) => {
-        const {newValue} = event.detail;
-        console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-        if (newValue) {
-            displayName.value = newValue.displayName;
-            uid.value = newValue.uid;
-        } else {
-            displayName.value = '';
-            uid.value = '';
-        }
-    });
-</script>
-</body>
+                <div class="ga-content-main">
+                    <main>
+                        <form method="post" action="/student/create">
+                            <h1>Create Student</h1>
+                            <input name="uid" type="hidden" id="uid"/>
+                            <div class="mb-3">
+                                <label class="form-label">Name:</label>
+                                <input class="form-control" type="text" id="display-name" th:field="${student.name}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Assignment Number:</label><input
+                                    class="form-control" type="text"
+                                    th:field="${student.assignmentNum}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Github Handle:</label>
+                                <input class="form-control" type="text" th:field="${student.githubHandle.handle}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">LinkedIn URL:</label>
+                                <input class="form-control" type="text" th:field="${student.linkedIn.url}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">IDE: </label>
+                                <input class="form-control" type="text" th:field="${student.ide}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">YouTube:</label>
+                                <input class="form-control" type="text" th:field="${student.youtube.profile}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Final Project:</label>
+                                <input class="form-control" type="text" th:field="${student.finalProject.title}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Resume:</label>
+                                <input class="form-control" type="text" th:field="${student.resume.resumeFile}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Networking:</label>
+                                <input class="form-control" type="text" th:field="${student.networking.meetups}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Website:</label>
+                                <input class="form-control" type="text" th:field="${student.website.url}"/>
+                            </div>
+                            <div class="mb-3">
+                                <input onfocus="assignUid()" class="form-control btn btn-primary"
+                                       type="submit" value="Create"/>
+                            </div>
+                        </form>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
+
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 
 </html>
 

--- a/src/main/resources/templates/student/read.html
+++ b/src/main/resources/templates/student/read.html
@@ -1,80 +1,65 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
 
-<body layout="layout-secured">
-<fbauth-element>
-    <div layout="layout-sidebar">
-        <header th:replace="~{fragments/header :: header(${activePage})}"></header>
-        <div class="sidebar-grid-area">
-            <nav class="navbar navbar-expand-lg navbar-light">
-                <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item"><a class="nav-link" href="/student/create">Create
-                            Student</a></li>
-                    </ul>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link" href="/student/create">Create
+                                    Student</a></li>
+                            </ul>
+                        </div>
+                    </nav>
                 </div>
-            </nav>
-        </div>
-        <div class="ga-content-main">
-            <main>
-                <table class="table">
-                    <thead>
-                    <tr>
-                        <th scope="col">Name:</th>
-                        <th scope="col">Assignment Number:</th>
-                        <th scope="col">Github Handle:</th>
-                        <th scope="col">LinkedIn:</th>
-                        <th scope="col">IDE:</th>
-                        <th scope="col">YouTube:</th>
-                        <th scope="col">Final Project:</th>
-                        <th scope="col">Resume:</th>
-                        <th scope="col">Networking:</th>
-                        <th scope="col">Website:</th>
-                        <th scope="col">View:</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr th:each="student: ${students}">
-                        <td><span th:text="${student.name}"></span></td>
-                        <td><span th:text="${student.assignmentNum}"></span></td>
-                        <td><span th:text="${student.githubHandle.handle}"></span></td>
-                        <td><span th:text="${student.linkedIn.url}"></span></td>
-                        <td><span th:text="${student.ide}"></span></td>
-                        <td><span th:text="${student.youtube.profile}"></span></td>
-                        <td><span th:text="${student.finalProject.title}"></span></td>
-                        <td><span th:text="${student.resume.resumeFile}"></span></td>
-                        <td><span th:text="${student.networking.meetups}"></span></td>
-                        <td><span th:text="${student.website.url}"></span></td>
-                        <td><a th:href="@{/student/update/{studentId}(studentId=${student.id})}">
+                <div class="ga-content-main">
+                    <main>
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Name:</th>
+                                    <th scope="col">Assignment Number:</th>
+                                    <th scope="col">Github Handle:</th>
+                                    <th scope="col">LinkedIn:</th>
+                                    <th scope="col">IDE:</th>
+                                    <th scope="col">YouTube:</th>
+                                    <th scope="col">Final Project:</th>
+                                    <th scope="col">Resume:</th>
+                                    <th scope="col">Networking:</th>
+                                    <th scope="col">Website:</th>
+                                    <th scope="col">View:</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr th:each="student: ${students}">
+                                    <td><span th:text="${student.name}"></span></td>
+                                    <td><span th:text="${student.assignmentNum}"></span></td>
+                                    <td><span th:text="${student.githubHandle.handle}"></span></td>
+                                    <td><span th:text="${student.linkedIn.url}"></span></td>
+                                    <td><span th:text="${student.ide}"></span></td>
+                                    <td><span th:text="${student.youtube.profile}"></span></td>
+                                    <td><span th:text="${student.finalProject.title}"></span></td>
+                                    <td><span th:text="${student.resume.resumeFile}"></span></td>
+                                    <td><span th:text="${student.networking.meetups}"></span></td>
+                                    <td><span th:text="${student.website.url}"></span></td>
+                                    <td><a th:href="@{/student/update/{studentId}(studentId=${student.id})}">
                                         <span><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                                    fill="currentColor" class="bi bi-view-list" viewBox="0 0 16 16">
                                                 <path
                                                         d="M3 4.5h10a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2zm0 1a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1H3zM1 2a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 2zm0 12a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 14z"/>
                                             </svg></span> </a></td>
-                    </tr>
-                    </tbody>
-                </table>
-            </main>
-        </div>
-        <div th:replace="~{fragments/footer :: footer}"></div>
-    </div>
-</fbauth-element>
-<script>
-    const fbauth = document.querySelector('fbauth-element');
-    const uid = document.getElementById('uid');
-    const displayName = document.getElementById('display-name');
-    fbauth.addEventListener('user-changed', (event) => {
-        const {newValue} = event.detail;
-        console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-        if (newValue) {
-            displayName.value = newValue.displayName;
-            uid.value = newValue.uid;
-        } else {
-            displayName.value = '';
-            uid.value = '';
-        }
-    });
-</script>
-</body>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 </html>

--- a/src/main/resources/templates/student/update.html
+++ b/src/main/resources/templates/student/update.html
@@ -1,90 +1,75 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
 
-<body layout="layout-secured">
-<fbauth-element>
-    <div layout="layout-sidebar">
-        <header th:replace="~{fragments/header :: header(${activePage})}"></header>
-        <div class="sidebar-grid-area">
-            <nav class="navbar navbar-expand-lg navbar-light">
-                <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item"><a class="nav-link active"
-                                                aria-current="page" href="/student/">Student Home</a></li>
-                        <li class="nav-item"><a class="nav-link" href="/student/create">Create
-                            Student</a></li>
-                    </ul>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link active"
+                                                        aria-current="page" href="/student/">Student Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="/student/create">Create
+                                    Student</a></li>
+                            </ul>
+                        </div>
+                    </nav>
                 </div>
-            </nav>
-        </div>
-        <div class="ga-content-main">
-            <main>
-                <form method="post" action="/student/update" class="mb-3">
-                    <input type="hidden" id="new-uid" th:field="${student.uid}"/>
-                    <input class="form-control" type="hidden" th:field="${student.id}"/>
+                <div class="ga-content-main">
+                    <main>
+                        <form method="post" action="/student/update" class="mb-3">
+                            <input type="hidden" id="new-uid" th:field="${student.uid}"/>
+                            <input class="form-control" type="hidden" th:field="${student.id}"/>
 
-                    <label class="form-label">Name: </label>
-                    <input class="form-control" type="text" th:field="${student.name}"/>
+                            <label class="form-label">Name: </label>
+                            <input class="form-control" type="text" th:field="${student.name}"/>
 
-                    <label class="form-label">Assignment Number: </label>
-                    <input class="form-control" type="text" th:field="${student.assignmentNum}"/>
+                            <label class="form-label">Assignment Number: </label>
+                            <input class="form-control" type="text" th:field="${student.assignmentNum}"/>
 
-                    <label class="form-label">Github Handle: </label>
-                    <input class="form-control" type="text" th:field="${student.githubHandle.handle}"/>
+                            <label class="form-label">Github Handle: </label>
+                            <input class="form-control" type="text" th:field="${student.githubHandle.handle}"/>
 
-                    <label class="form-label">LinkedIn: </label>
-                    <input class="form-control" type="text" th:field="${student.linkedIn.url}"/>
+                            <label class="form-label">LinkedIn: </label>
+                            <input class="form-control" type="text" th:field="${student.linkedIn.url}"/>
 
-                    <label class="form-label">IDE: </label>
-                    <input class="form-control" type="text" th:field="${student.ide}"/>
+                            <label class="form-label">IDE: </label>
+                            <input class="form-control" type="text" th:field="${student.ide}"/>
 
-                    <label class="form-label">YouTube: </label>
-                    <input class="form-control" type="text" th:field="${student.youtube.profile}"/>
+                            <label class="form-label">YouTube: </label>
+                            <input class="form-control" type="text" th:field="${student.youtube.profile}"/>
 
-                    <label class="form-label">Final Project: </label>
-                    <input class="form-control" type="text" th:field="${student.finalProject.title}"/>
+                            <label class="form-label">Final Project: </label>
+                            <input class="form-control" type="text" th:field="${student.finalProject.title}"/>
 
-                    <label class="form-label">Resume: </label>
-                    <input class="form-control" type="text" th:field="${student.resume.resumeFile}"/>
+                            <label class="form-label">Resume: </label>
+                            <input class="form-control" type="text" th:field="${student.resume.resumeFile}"/>
 
-                    <label class="form-label">Networking: </label>
-                    <input class="form-control" type="text" th:field="${student.networking.meetups}"/>
+                            <label class="form-label">Networking: </label>
+                            <input class="form-control" type="text" th:field="${student.networking.meetups}"/>
 
-                    <label class="form-label">Website: </label>
-                    <input class="form-control" type="text" th:field="${student.website.url}"/>
+                            <label class="form-label">Website: </label>
+                            <input class="form-control" type="text" th:field="${student.website.url}"/>
 
-                    <input onfocus="assignUid()" class="form-control btn btn-primary mt-3" type="submit"
-                           value="Update"/>
+                            <input onfocus="assignUid()" class="form-control btn btn-primary mt-3" type="submit"
+                                   value="Update"/>
 
-                </form>
-                <form method="post" action="/student/delete" class="mb-3">
-                    <input type="hidden" id="new-uid" th:field="${student.id}"/>
-                    <input class="form-control btn btn-danger" type="submit" value="Delete"/>
-                </form>
+                        </form>
+                        <form method="post" action="/student/delete" class="mb-3">
+                            <input type="hidden" id="new-uid" th:field="${student.id}"/>
+                            <input class="form-control btn btn-danger" type="submit" value="Delete"/>
+                        </form>
 
-            </main>
-        </div>
-        <div th:replace="~{fragments/footer :: footer}"></div>
-    </div>
-</fbauth-element>
-<script>
-    const fbauth = document.querySelector('fbauth-element');
-    const uid = document.getElementById('uid');
-    const displayName = document.getElementById('display-name');
-    fbauth.addEventListener('user-changed', (event) => {
-        const {newValue} = event.detail;
-        console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-        if (newValue) {
-            displayName.value = newValue.displayName;
-            uid.value = newValue.uid;
-        } else {
-            displayName.value = '';
-            uid.value = '';
-        }
-    });
-</script>
-</body>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 
 </html>
 

--- a/src/main/resources/templates/user-history/create.html
+++ b/src/main/resources/templates/user-history/create.html
@@ -1,58 +1,44 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
 
-<body layout="layout-secured">
-	<fbauth-element>
-		<div layout="layout-sidebar">
-			<header th:replace="~{fragments/header :: header(${activePage})}"></header>
-			<div class="sidebar-grid-area">
-				<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="collapse navbar-collapse" id="navbarNav">
-						<ul class="navbar-nav">
-							<li class="nav-item"><a class="nav-link" href="/user-history/create">Create
-									User History</a></li>
-						</ul>
-					</div>
-				</nav>
-			</div>
-			<div class="ga-content-main">
-				<main>
-					<form method="post" action="/user-history/create">
-						<h1>Create User History</h1>
-						<div class="mb-3">
-							<label class="form-label">Name:</label>
-							<input class="form-control" type="text" id="display-name" th:field="${userHistory.name}" />
-						</div>
-						<div class="mb-3">
-							<label class="form-label">Issue #:</label>
-							<input class="form-control" type="text" th:field="${userHistory.issue}" />
-						</div>
-						<div class="mb-3">
-							<input class="form-control btn btn-primary" type="submit" value="Create" />
-						</div>
-					</form>
-				</main>
-			</div>
-			<div th:replace="~{fragments/footer :: footer}"></div>
-		</div>
-	</fbauth-element>
-	<script>
-		const fbauth = document.querySelector('fbauth-element');
-		const uid = document.getElementById('uid');
-		const displayName = document.getElementById('display-name');
-		fbauth.addEventListener('user-changed', (event) => {
-			const {newValue} = event.detail;
-			console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-			if (newValue) {
-				displayName.value = newValue.displayName;
-				uid.value = newValue.uid;
-			} else {
-				displayName.value = '';
-				uid.value = '';
-			}
-		});
-	</script>
-</body>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link" href="/user-history/create">Create
+                                    User History</a></li>
+                            </ul>
+                        </div>
+                    </nav>
+                </div>
+                <div class="ga-content-main">
+                    <main>
+                        <form method="post" action="/user-history/create">
+                            <h1>Create User History</h1>
+                            <div class="mb-3">
+                                <label class="form-label">Name:</label>
+                                <input class="form-control" type="text" id="display-name"
+                                       th:field="${userHistory.name}"/>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Issue #:</label>
+                                <input class="form-control" type="text" th:field="${userHistory.issue}"/>
+                            </div>
+                            <div class="mb-3">
+                                <input class="form-control btn btn-primary" type="submit" value="Create"/>
+                            </div>
+                        </form>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 
 </html>

--- a/src/main/resources/templates/user-history/read.html
+++ b/src/main/resources/templates/user-history/read.html
@@ -1,68 +1,54 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
-<body layout="layout-secured">
-<fbauth-element>
-    <div layout="layout-sidebar">
-        <header th:replace="~{fragments/header :: header(${activePage})}"></header>
-        <div class="sidebar-grid-area">
-            <nav class="navbar navbar-expand-lg navbar-light">
-                <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item"><a class="nav-link" href="/user-history/create">Create
-                            User History</a></li>
-                    </ul>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link" href="/user-history/create">Create
+                                    User History</a></li>
+                            </ul>
+                        </div>
+                    </nav>
                 </div>
-            </nav>
-        </div>
-        <div class="ga-content-main">
-            <main>
-                <table class="table">
-                    <thead>
-                    <tr>
-                        <th scope="col">Name:</th>
-                        <th scope="col">Issue</th>
-                        <th scope="col">Date:</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr th:each="userHistory: ${userHistorys}">
+                <div class="ga-content-main">
+                    <main>
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Name:</th>
+                                    <th scope="col">Issue</th>
+                                    <th scope="col">Date:</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr th:each="userHistory: ${userHistorys}">
 
-                        <td><span th:text="${userHistory.name}"></span></td>
-                        <td><span th:text="${userHistory.issue}"></span></td>
-                        <td><span th:text="${userHistory.date}"></span></td>
+                                    <td><span th:text="${userHistory.name}"></span></td>
+                                    <td><span th:text="${userHistory.issue}"></span></td>
+                                    <td><span th:text="${userHistory.date}"></span></td>
 
-                        <td><a th:href="@{/user-history/update/{userHistoryId}(userHistoryId=${userHistory.id})}">
+                                    <td>
+                                        <a th:href="@{/user-history/update/{userHistoryId}(userHistoryId=${userHistory.id})}">
 					<span><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                                class="bi bi-view-list" viewBox="0 0 16 16">
   <path d="M3 4.5h10a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2zm0 1a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1H3zM1 2a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 2zm0 12a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 14z"/>
 </svg></span> </a></td>
-                    </tr>
+                                </tr>
 
-                    </tbody>
-                </table>
-            </main>
-        </div>
-        <div th:replace="~{fragments/footer :: footer}"></div>
-    </div>
-</fbauth-element>
-<script>
-    const fbauth = document.querySelector('fbauth-element');
-    const uid = document.getElementById('uid');
-    const displayName = document.getElementById('display-name');
-    fbauth.addEventListener('user-changed', (event) => {
-        const {newValue} = event.detail;
-        console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-        if (newValue) {
-            displayName.value = newValue.displayName;
-            uid.value = newValue.uid;
-        } else {
-            displayName.value = '';
-            uid.value = '';
-        }
-    });
-</script>
-</body>
+                            </tbody>
+                        </table>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 </html>
 
 

--- a/src/main/resources/templates/user-history/update.html
+++ b/src/main/resources/templates/user-history/update.html
@@ -1,65 +1,51 @@
 <!DOCTYPE html>
 <html xmlns:th="http://thymeleaf.org">
-<div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
-<body layout="layout-secured">
-	<fbauth-element>
-	<div layout="layout-sidebar">
-		<header th:replace="~{fragments/header :: header(${activePage})}"></header>
-		<div class="sidebar-grid-area">
-			<nav class="navbar navbar-expand-lg navbar-light">
-				<div class="collapse navbar-collapse" id="navbarNav">
-					<ul class="navbar-nav">
-						<li class="nav-item"><a class="nav-link active"
-							aria-current="page" href="/user-history/">User History Home</a></li>
-						<li class="nav-item"><a class="nav-link"
-							href="/user-history/create">Create User History</a></li>
-					</ul>
-				</div>
-			</nav>
-		</div>
-		<div class="ga-content-main">
-			<main>
-				<form method="post" action="/user-history/update" class="mb-3">
-					<input class="form-control" type="hidden" th:field="${userHistory.id}"/>
+    <div th:replace="~{fragments/head :: head(${pageTitle})}"></div>
+    <body layout="layout-secured">
+        <fbauth-element>
+            <div layout="layout-sidebar">
+                <header th:replace="~{fragments/header :: header(${activePage})}"></header>
+                <div class="sidebar-grid-area">
+                    <nav class="navbar navbar-expand-lg navbar-light">
+                        <div class="collapse navbar-collapse" id="navbarNav">
+                            <ul class="navbar-nav">
+                                <li class="nav-item"><a class="nav-link active"
+                                                        aria-current="page" href="/user-history/">User History Home</a>
+                                </li>
+                                <li class="nav-item"><a class="nav-link"
+                                                        href="/user-history/create">Create User History</a></li>
+                            </ul>
+                        </div>
+                    </nav>
+                </div>
+                <div class="ga-content-main">
+                    <main>
+                        <form method="post" action="/user-history/update" class="mb-3">
+                            <input class="form-control" type="hidden" th:field="${userHistory.id}"/>
 
-					<label class="form-label">Name:</label>
-					<input class="form-control" type="text" th:field="${userHistory.name}"/>
+                            <label class="form-label">Name:</label>
+                            <input class="form-control" type="text" th:field="${userHistory.name}"/>
 
-					<label class="form-label">Issue:</label>
-					<input class="form-control" type="text" th:field="${userHistory.issue}" />
+                            <label class="form-label">Issue:</label>
+                            <input class="form-control" type="text" th:field="${userHistory.issue}"/>
 
-					<label class="form-label">Date:</label>
-					<label class="form-label" th:text="${userHistory.date}"></label>
-					<input class="form-control" type="hidden" th:field="${userHistory.date}"/>
+                            <label class="form-label">Date:</label>
+                            <label class="form-label" th:text="${userHistory.date}"></label>
+                            <input class="form-control" type="hidden" th:field="${userHistory.date}"/>
 
-					<input class="form-control btn btn-primary mt-3" type="submit" value="Update"/>
-				</form>
-				<form method="post" action="/user-history/delete" class="mb-3">
-					<input type="hidden" th:field="${userHistory.id}" />
-					<input class="form-control btn btn-danger" type="submit" value="Delete"/>
-				</form>
-			</main>
-		</div>
-		<div th:replace="~{fragments/footer :: footer}"></div>
-	</div>
-	</fbauth-element>
-	<script>
-    const fbauth = document.querySelector('fbauth-element');
-    const uid = document.getElementById('uid');
-    const displayName = document.getElementById('display-name');
-    fbauth.addEventListener('user-changed', (event) => {
-        const {newValue} = event.detail;
-        console.log("SETTING UID TO " + newValue.uid + " AND DISPLAY NAME TO " + newValue.displayName);
-        if (newValue) {
-            displayName.value = newValue.displayName;
-            uid.value = newValue.uid;
-        } else {
-            displayName.value = '';
-            uid.value = '';
-        }
-    });
-</script>
-</body>
+                            <input class="form-control btn btn-primary mt-3" type="submit" value="Update"/>
+                        </form>
+                        <form method="post" action="/user-history/delete" class="mb-3">
+                            <input type="hidden" th:field="${userHistory.id}"/>
+                            <input class="form-control btn btn-danger" type="submit" value="Delete"/>
+                        </form>
+                    </main>
+                </div>
+                <div th:replace="~{fragments/footer :: footer}"></div>
+            </div>
+        </fbauth-element>
+        <div th:replace="~{fragments/authscript :: script}"></div>
+    </body>
 </html>
 
 


### PR DESCRIPTION
Refactor the `<script>` tags at the bottom of each HTML page within the `/templates` directory by converting them into a reusable fragment. The newly created script fragment has been added to the fragment folder, enabling easier updates and maintenance across the platform.

closes: #412