### PR TITLE
Toggle drop on Checkin Update resolved

### DIFF
--- a/src/main/resources/templates/checkin/update.html
+++ b/src/main/resources/templates/checkin/update.html
@@ -98,7 +98,7 @@
         <div th:replace="~{fragments/footer :: footer}"></div>
     </div>
 </fbauth-element>
-
+<div th:replace="~{fragments/togglescript :: script}"></div>
 <div th:replace="~{fragments/authscript :: script}"></div>
 <div th:replace="~{fragments/themeswitchscript :: script}"></div>
 </body>


### PR DESCRIPTION
checkin/update.html did not have the fragment reference  at the bottom of the page. Now that fragment reference is there we can successfully toggle the Checkin Update page. closes #502