### PR TITLE
Checkin auto-created resolved

### DIFF
--- a/src/main/java/com/coderscampus/cp/web/SpringProjectController.java
+++ b/src/main/java/com/coderscampus/cp/web/SpringProjectController.java
@@ -37,7 +37,7 @@ public class SpringProjectController {
         String uid = (String)httpSession.getAttribute("uid");
         String displayName = (String)httpSession.getAttribute("displayName");
         Checkin checkin = new Checkin();
-        checkin = checkinService.saveByUid(checkin, uid);
+//        checkin = checkinService.saveByUid(checkin, uid);
         Student student = new Student();
 		model.put("student", student);
     	return "dashboard";


### PR DESCRIPTION
Students/users on the app can navigate anywhere on the application and not have checkin's auto-created for them when they didn't intend for them to be created. closes #507