### PR TITLE
Added time methods to Checkin, created CheckinListener

### DIFF
--- a/src/main/java/com/coderscampus/cp/domain/Checkin.java
+++ b/src/main/java/com/coderscampus/cp/domain/Checkin.java
@@ -2,9 +2,10 @@ package com.coderscampus.cp.domain;
 
 import jakarta.persistence.*;
 
+import java.math.BigInteger;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
-
 @Entity
 public class Checkin {
 	@Id
@@ -22,6 +23,8 @@ public class Checkin {
 	private Instant endTime;
 	private CodingType codingType;
 	private Integer issueNumber;
+	private BigInteger timeInClassInSeconds;
+
 	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	@JoinColumn(name = "student_id")
 	private Student student;
@@ -138,12 +141,28 @@ public class Checkin {
 		this.student = student;
 	}
 
+	public Boolean getSetUp() {
+		return isSetUp;
+	}
+
+	public void setSetUp(Boolean setUp) {
+		isSetUp = setUp;
+	}
+
+	public BigInteger getTimeInClassInSeconds() {
+		return timeInClassInSeconds;
+	}
+
+	public void setTimeInClassInSeconds(BigInteger timeInClassInSeconds) {
+		this.timeInClassInSeconds = timeInClassInSeconds;
+	}
+
 	// ENUMS
 	public enum CodingType{
 		FOUNDATIONS, CRUD, CODE_REVIEW, DESIGN, DOCUMENTATION
 	}
 	public enum Role{
-		FOUNDATIONS, OBSERVER,  CODER, GUIDE, SCRUM_MASTER, PRODUCT_OWNER
+		FOUNDATIONS, OBSERVER, CODER, GUIDE, SCRUM_MASTER, PRODUCT_OWNER
 	}
 
 	@Override
@@ -152,7 +171,7 @@ public class Checkin {
 				"id=" + id +
 				", uid='" + uid + '\'' +
 				", date=" + date +
-				", assignment=" + nextAssignment +
+				", nextAssignment=" + nextAssignment +
 				", blockers=" + blockers +
 				", blockerDescription='" + blockerDescription + '\'' +
 				", isSetUp=" + isSetUp +
@@ -160,9 +179,18 @@ public class Checkin {
 				", role=" + role +
 				", startTime=" + startTime +
 				", endTime=" + endTime +
-				", issueNumber=" + issueNumber +
 				", codingType=" + codingType +
-				", student=" + student +
+				", issueNumber=" + issueNumber +
+				", timeInClassInSeconds=" + timeInClassInSeconds +
 				'}';
+	}
+
+	public void calculateTimeInClass() {
+		if (startTime != null && endTime != null) {
+			long seconds = Duration.between(startTime, endTime).getSeconds();
+			setTimeInClassInSeconds(BigInteger.valueOf(seconds));
+		} else {
+			setTimeInClassInSeconds(BigInteger.ZERO);
+		}
 	}
 }

--- a/src/main/java/com/coderscampus/cp/domain/CheckinListener.java
+++ b/src/main/java/com/coderscampus/cp/domain/CheckinListener.java
@@ -1,0 +1,12 @@
+package com.coderscampus.cp.domain;
+
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+public class CheckinListener {
+    @PrePersist
+    @PreUpdate
+    public void beforeSave(Checkin checkin) {
+        checkin.calculateTimeInClass();
+    }
+}


### PR DESCRIPTION
## CheckinListener
### Spring JPA Annotations: @PrePersist and @PreUpdate

- Before any **Checkin** is saved across the CP app, the **CheckinListener** intercepts and calls the **calculateTimeInClass** method for the **Checkin** entity. Specifically, the **beforeSave** method (the name is not important) in the **CheckinListener** is invoked automatically by the persistence context right before a Checkin entity is either created (persisted) for the first time or updated. 
- During these events, the calculateTimeInClass method on the Checkin object is called.


```
public class CheckinListener {
    @PrePersist
    @PreUpdate
    public void beforeSave(Checkin checkin) {
        checkin.calculateTimeInClass();
    }
}
```

Note: "beforeSave" is NOT using a repository method prefix and can theoretically be named anything (as opposed to Spring JPA's "saveBy___" methods).

## Checkin:
### Taking Advantage of **Instant** to calculate **Duration**

- Because **startTime** and **endTime** are **Instants**, the **Duration** object (java.time.Duration) can be invoked to easily calculate time using **Duration's** built in **getSeconds()** method. **Duration** returns a **long**, we convert it to a **BigInteger** and set **timeInClassInSeconds** property:

```
	public void calculateTimeInClass() {
		if (startTime != null && endTime != null) {
			long seconds = Duration.between(startTime, endTime).getSeconds();
			setTimeInClassInSeconds(BigInteger.valueOf(seconds));
		} else {
			setTimeInClassInSeconds(BigInteger.ZERO);
		}
	}
```

- We place calculateTimeInClass within the Checkin entity as a practical design choice. This method acts as an implicit setter for **timeInClassInSeconds**, leveraging the direct availability of startTime and endTime within the same object. This is done to avoid unnecessary external dependencies, data manipulation, and unnecessary additional fetches to the repository (e.g. at the service level) when the same **Checkin** object is already present at hand when we set the **endTime**. 
- In other words, we use **endTime** to kill two birds with one stone, and make it clear from the architecture of the code that **timeInClassInSeconds is set automatically**.  

