### PR TITLE
issue919 add backend REST layers

### DIFF
--- a/src/main/java/com/coderscampus/cp/dto/ApiDtos.java
+++ b/src/main/java/com/coderscampus/cp/dto/ApiDtos.java
@@ -1,0 +1,193 @@
+package com.coderscampus.cp.dto;
+
+import com.coderscampus.cp.domain.Finalproject;
+import com.coderscampus.cp.domain.GitHub;
+import com.coderscampus.cp.domain.LinkedIn;
+import com.coderscampus.cp.domain.Networkingperson;
+import com.coderscampus.cp.domain.Networkingresource;
+import com.coderscampus.cp.domain.Resume;
+
+import java.util.Map;
+
+public final class ApiDtos {
+
+    private ApiDtos() {
+    }
+
+    public record ApiErrorResponse(String message, Map<String, String> errors) {
+    }
+
+    public record GitHubProfileRequest(Boolean handle, Boolean enhancedReadMe, Boolean renamedAssignments,
+            Boolean pinnedRepos, String externalLinks, Boolean image, Boolean headline, Boolean contactDetails,
+            String url) {
+        public GitHub toDomain(Long id) {
+            GitHub gitHub = new GitHub();
+            gitHub.setId(id);
+            gitHub.setHandle(handle);
+            gitHub.setEnhancedReadMe(enhancedReadMe);
+            gitHub.setRenamedAssignments(renamedAssignments);
+            gitHub.setPinnedRepos(pinnedRepos);
+            gitHub.setExternalLinks(externalLinks);
+            gitHub.setImage(image);
+            gitHub.setHeadline(headline);
+            gitHub.setContactDetails(contactDetails);
+            gitHub.setUrl(url);
+            return gitHub;
+        }
+    }
+
+    public record GitHubProfileResponse(Long id, Long studentId, Boolean handle, Boolean enhancedReadMe,
+            Boolean renamedAssignments, Boolean pinnedRepos, String externalLinks, Boolean image, Boolean headline,
+            Boolean contactDetails, String url) {
+        public static GitHubProfileResponse from(GitHub gitHub) {
+            return new GitHubProfileResponse(gitHub.getId(), resolveStudentId(gitHub.getStudent()), gitHub.getHandle(),
+                    gitHub.getEnhancedReadMe(), gitHub.getRenamedAssignments(), gitHub.getPinnedRepos(),
+                    gitHub.getExternalLinks(), gitHub.getImage(), gitHub.getHeadline(), gitHub.getContactDetails(),
+                    gitHub.getUrl());
+        }
+    }
+
+    public record LinkedInProfileRequest(String firstName, String lastName, String url, Boolean banner, Boolean about,
+            Boolean featuredPosts, Boolean activity, Boolean skills, Boolean email, Boolean biography,
+            Boolean education, Boolean experience, Boolean location, Boolean image, Boolean title) {
+        public LinkedIn toDomain(Long id) {
+            LinkedIn linkedIn = new LinkedIn();
+            linkedIn.setId(id);
+            linkedIn.setFirstName(firstName);
+            linkedIn.setLastName(lastName);
+            linkedIn.setUrl(url);
+            linkedIn.setBanner(banner);
+            linkedIn.setAbout(about);
+            linkedIn.setFeaturedPosts(featuredPosts);
+            linkedIn.setActivity(activity);
+            linkedIn.setSkills(skills);
+            linkedIn.setEmail(email);
+            linkedIn.setBiography(biography);
+            linkedIn.setEducation(education);
+            linkedIn.setExperience(experience);
+            linkedIn.setLocation(location);
+            linkedIn.setImage(image);
+            linkedIn.setTitle(title);
+            return linkedIn;
+        }
+    }
+
+    public record LinkedInProfileResponse(Long id, Long studentId, String firstName, String lastName, String url,
+            Boolean banner, Boolean about, Boolean featuredPosts, Boolean activity, Boolean skills, Boolean email,
+            Boolean biography, Boolean education, Boolean experience, Boolean location, Boolean image,
+            Boolean title) {
+        public static LinkedInProfileResponse from(LinkedIn linkedIn) {
+            return new LinkedInProfileResponse(linkedIn.getId(), resolveStudentId(linkedIn.getStudent()),
+                    linkedIn.getFirstName(), linkedIn.getLastName(), linkedIn.getUrl(), linkedIn.getBanner(),
+                    linkedIn.getAbout(), linkedIn.getFeaturedPosts(), linkedIn.getActivity(), linkedIn.getSkills(),
+                    linkedIn.getEmail(), linkedIn.getBiography(), linkedIn.getEducation(), linkedIn.getExperience(),
+                    linkedIn.getLocation(), linkedIn.getImage(), linkedIn.getTitle());
+        }
+    }
+
+    public record ResumeRequest(String phoneNumber, String email, String city, String state, String linkedIn,
+            String gitHub, String summary, String skills, String workExperience, String education, String projects) {
+        public Resume toDomain(Long id) {
+            Resume resume = new Resume();
+            resume.setId(id);
+            resume.setPhoneNumber(phoneNumber);
+            resume.setEmail(email);
+            resume.setCity(city);
+            resume.setState(state);
+            resume.setLinkedIn(linkedIn);
+            resume.setGitHub(gitHub);
+            resume.setSummary(summary);
+            resume.setSkills(skills);
+            resume.setWorkExperience(workExperience);
+            resume.setEducation(education);
+            resume.setProjects(projects);
+            return resume;
+        }
+    }
+
+    public record ResumeResponse(Long id, Long studentId, String phoneNumber, String email, String city, String state,
+            String linkedIn, String gitHub, String summary, String skills, String workExperience, String education,
+            String projects) {
+        public static ResumeResponse from(Resume resume) {
+            return new ResumeResponse(resume.getId(), resolveStudentId(resume.getStudent()), resume.getPhoneNumber(),
+                    resume.getEmail(), resume.getCity(), resume.getState(), resume.getLinkedIn(), resume.getGitHub(),
+                    resume.getSummary(), resume.getSkills(), resume.getWorkExperience(), resume.getEducation(),
+                    resume.getProjects());
+        }
+    }
+
+    public record FinalProjectRequest(String projectName, String proposal, String description, String crud,
+            String tables, String views) {
+        public Finalproject toDomain(Long id) {
+            Finalproject finalproject = new Finalproject();
+            finalproject.setId(id);
+            finalproject.setProjectName(projectName);
+            finalproject.setProposal(proposal);
+            finalproject.setDescription(description);
+            finalproject.setCrud(crud);
+            finalproject.setTables(tables);
+            finalproject.setViews(views);
+            return finalproject;
+        }
+    }
+
+    public record FinalProjectResponse(Long id, Long studentId, String projectName, String proposal,
+            String description, String crud, String tables, String views) {
+        public static FinalProjectResponse from(Finalproject finalproject) {
+            return new FinalProjectResponse(finalproject.getId(), resolveStudentId(finalproject.getStudent()),
+                    finalproject.getProjectName(), finalproject.getProposal(), finalproject.getDescription(),
+                    finalproject.getCrud(), finalproject.getTables(), finalproject.getViews());
+        }
+    }
+
+    public record NetworkingPersonRequest(String name, String linkedinUrl, String techStack, String firstContactDate,
+            String lastContactDate, String otherNotesAboutPerson) {
+        public Networkingperson toDomain(Long id) {
+            Networkingperson person = new Networkingperson();
+            person.setId(id);
+            person.setName(name);
+            person.setLinkedinUrl(linkedinUrl);
+            person.setTechStack(techStack);
+            person.setFirstContactDate(firstContactDate);
+            person.setLastContactDate(lastContactDate);
+            person.setOtherNotesAboutPerson(otherNotesAboutPerson);
+            return person;
+        }
+    }
+
+    public record NetworkingPersonResponse(Long id, Long studentId, String name, String linkedinUrl, String techStack,
+            String firstContactDate, String lastContactDate, String otherNotesAboutPerson) {
+        public static NetworkingPersonResponse from(Networkingperson person) {
+            return new NetworkingPersonResponse(person.getId(), resolveStudentId(person.getStudent()), person.getName(),
+                    person.getLinkedinUrl(), person.getTechStack(), person.getFirstContactDate(),
+                    person.getLastContactDate(), person.getOtherNotesAboutPerson());
+        }
+    }
+
+    public record NetworkingResourceRequest(String resourceName, String type, String cost, String geographicScope,
+            String notes) {
+        public Networkingresource toDomain(Long id) {
+            Networkingresource resource = new Networkingresource();
+            resource.setId(id);
+            resource.setResourceName(resourceName);
+            resource.setType(type);
+            resource.setCost(cost);
+            resource.setGeographicScope(geographicScope);
+            resource.setNotes(notes);
+            return resource;
+        }
+    }
+
+    public record NetworkingResourceResponse(Long id, Long studentId, String resourceName, String type, String cost,
+            String geographicScope, String notes) {
+        public static NetworkingResourceResponse from(Networkingresource resource) {
+            return new NetworkingResourceResponse(resource.getId(), resolveStudentId(resource.getStudent()),
+                    resource.getResourceName(), resource.getType(), resource.getCost(), resource.getGeographicScope(),
+                    resource.getNotes());
+        }
+    }
+
+    private static Long resolveStudentId(com.coderscampus.cp.domain.Student student) {
+        return student == null ? null : student.getId();
+    }
+}

--- a/src/main/java/com/coderscampus/cp/repository/FinalprojectRepository.java
+++ b/src/main/java/com/coderscampus/cp/repository/FinalprojectRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface FinalprojectRepository extends JpaRepository<Finalproject, Long> {
@@ -15,8 +16,9 @@ public interface FinalprojectRepository extends JpaRepository<Finalproject, Long
     List<Finalproject> findAllWithStudents();
 
     List<Finalproject> findByStudent(Student student);
+    List<Finalproject> findByStudentUid(String uid);
+    Optional<Finalproject> findByIdAndStudentUid(Long id, String uid);
 }
-
 
 
 

--- a/src/main/java/com/coderscampus/cp/repository/GitHubRepository.java
+++ b/src/main/java/com/coderscampus/cp/repository/GitHubRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface GitHubRepository extends JpaRepository<GitHub, Long> {
     List<GitHub> findByStudent(Student student);
+    List<GitHub> findByStudentUid(String uid);
+    boolean existsByStudentUid(String uid);
+    Optional<GitHub> findByIdAndStudentUid(Long id, String uid);
 }
-
 

--- a/src/main/java/com/coderscampus/cp/repository/LinkedInRepository.java
+++ b/src/main/java/com/coderscampus/cp/repository/LinkedInRepository.java
@@ -7,9 +7,12 @@ import com.coderscampus.cp.domain.LinkedIn;
 import com.coderscampus.cp.domain.Student;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface LinkedInRepository extends JpaRepository<LinkedIn, Long> {
     List<LinkedIn> findByStudent(Student student);
+    List<LinkedIn> findByStudentUid(String uid);
+    boolean existsByStudentUid(String uid);
+    Optional<LinkedIn> findByIdAndStudentUid(Long id, String uid);
 }
-

--- a/src/main/java/com/coderscampus/cp/repository/NetworkingpersonRepository.java
+++ b/src/main/java/com/coderscampus/cp/repository/NetworkingpersonRepository.java
@@ -6,10 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface NetworkingpersonRepository extends JpaRepository<Networkingperson, Long> {
     List<Networkingperson> findByStudent(Student student);
+    List<Networkingperson> findByStudentUid(String uid);
+    Optional<Networkingperson> findByIdAndStudentUid(Long id, String uid);
 }
-
 

--- a/src/main/java/com/coderscampus/cp/repository/NetworkingresourceRepository.java
+++ b/src/main/java/com/coderscampus/cp/repository/NetworkingresourceRepository.java
@@ -6,10 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface NetworkingresourceRepository extends JpaRepository<Networkingresource, Long> {
     List<Networkingresource> findByStudent(Student student);
+    List<Networkingresource> findByStudentUid(String uid);
+    Optional<Networkingresource> findByIdAndStudentUid(Long id, String uid);
 }
-
 

--- a/src/main/java/com/coderscampus/cp/repository/ResumeRepository.java
+++ b/src/main/java/com/coderscampus/cp/repository/ResumeRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
     List<Resume> findByStudent(Student student);
+    List<Resume> findByStudentUid(String uid);
+    boolean existsByStudentUid(String uid);
+    Optional<Resume> findByIdAndStudentUid(Long id, String uid);
 }
-
 

--- a/src/main/java/com/coderscampus/cp/service/FinalprojectService.java
+++ b/src/main/java/com/coderscampus/cp/service/FinalprojectService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class FinalprojectService {
@@ -42,6 +43,24 @@ public class FinalprojectService {
 
     public List<Finalproject> findAll() {
         return finalprojectRepo.findAllWithStudents();
+    }
+
+    public List<Finalproject> findByUid(String uid) {
+        return finalprojectRepo.findByStudentUid(uid);
+    }
+
+    public Optional<Finalproject> findOptionalById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return finalprojectRepo.findById(id);
+    }
+
+    public Optional<Finalproject> findByIdAndUid(Long id, String uid) {
+        if (id == null || uid == null) {
+            return Optional.empty();
+        }
+        return finalprojectRepo.findByIdAndStudentUid(id, uid);
     }
 
     public Finalproject findById(Long id) {

--- a/src/main/java/com/coderscampus/cp/service/GitHubService.java
+++ b/src/main/java/com/coderscampus/cp/service/GitHubService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Service
@@ -43,6 +44,24 @@ public class GitHubService {
 
     public List<GitHub> findAll() {
         return gitHubRepo.findAll();
+    }
+
+    public List<GitHub> findByUid(String uid) {
+        return gitHubRepo.findByStudentUid(uid);
+    }
+
+    public Optional<GitHub> findOptionalById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return gitHubRepo.findById(id);
+    }
+
+    public Optional<GitHub> findByIdAndUid(Long id, String uid) {
+        if (id == null || uid == null) {
+            return Optional.empty();
+        }
+        return gitHubRepo.findByIdAndStudentUid(id, uid);
     }
 
     public GitHub findById(Long id) {
@@ -81,12 +100,6 @@ public class GitHubService {
 );
 
     public boolean checkIfExists(String uid) {
-        List <GitHub> gitHubs = findAll();
-        for (GitHub gitHub : gitHubs) {
-            if (gitHub.getStudent().getUid().equals(uid)) {
-                return true;
-            }
-        }
-        return false;
+        return uid != null && gitHubRepo.existsByStudentUid(uid);
     }
 }

--- a/src/main/java/com/coderscampus/cp/service/LinkedInService.java
+++ b/src/main/java/com/coderscampus/cp/service/LinkedInService.java
@@ -1,7 +1,6 @@
 package com.coderscampus.cp.service;
 
 import com.coderscampus.cp.domain.LinkedIn;
-import com.coderscampus.cp.domain.Resume;
 import com.coderscampus.cp.domain.Student;
 import com.coderscampus.cp.repository.LinkedInRepository;
 import com.coderscampus.cp.repository.StudentRepository;
@@ -10,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Service
@@ -43,6 +43,24 @@ public class LinkedInService {
 
     public List<LinkedIn> findAll() {
         return linkedInRepo.findAll();
+    }
+
+    public List<LinkedIn> findByUid(String uid) {
+        return linkedInRepo.findByStudentUid(uid);
+    }
+
+    public Optional<LinkedIn> findOptionalById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return linkedInRepo.findById(id);
+    }
+
+    public Optional<LinkedIn> findByIdAndUid(Long id, String uid) {
+        if (id == null || uid == null) {
+            return Optional.empty();
+        }
+        return linkedInRepo.findByIdAndStudentUid(id, uid);
     }
 
     public LinkedIn findById(Long id) {
@@ -81,13 +99,7 @@ public class LinkedInService {
 );
 
     public boolean checkIfExists(String uid) {
-        List<LinkedIn> linkedIns = findAll();
-        for (LinkedIn linkedIn : linkedIns) {
-            if (linkedIn.getStudent().getUid().equals(uid)) {
-                return true;
-            }
-        }
-        return false;
+        return uid != null && linkedInRepo.existsByStudentUid(uid);
     }
 }
 

--- a/src/main/java/com/coderscampus/cp/service/NetworkingpersonService.java
+++ b/src/main/java/com/coderscampus/cp/service/NetworkingpersonService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class NetworkingpersonService {
@@ -43,6 +44,10 @@ public class NetworkingpersonService {
         return networkingpersonRepo.findAll();
     }
 
+    public List<Networkingperson> findByUid(String uid) {
+        return networkingpersonRepo.findByStudentUid(uid);
+    }
+
     public List<Networkingperson> findListByUid(String uid) {
         List<Networkingperson> listForStudent = new ArrayList<>();
         List<Networkingperson> allPersons = networkingpersonRepo.findAll();
@@ -59,6 +64,20 @@ public class NetworkingpersonService {
             return null;
         }
         return networkingpersonRepo.findById(id).get();
+    }
+
+    public Optional<Networkingperson> findOptionalById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return networkingpersonRepo.findById(id);
+    }
+
+    public Optional<Networkingperson> findByIdAndUid(Long id, String uid) {
+        if (id == null || uid == null) {
+            return Optional.empty();
+        }
+        return networkingpersonRepo.findByIdAndStudentUid(id, uid);
     }
 
     public void delete(Networkingperson networkingperson) {

--- a/src/main/java/com/coderscampus/cp/service/NetworkingresourceService.java
+++ b/src/main/java/com/coderscampus/cp/service/NetworkingresourceService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class NetworkingresourceService {
@@ -44,6 +45,10 @@ public class NetworkingresourceService {
         return networkingresourcesRepo.findAll();
     }
 
+    public List<Networkingresource> findByUid(String uid) {
+        return networkingresourcesRepo.findByStudentUid(uid);
+    }
+
     public List<Networkingresource> findListByUid(String uid) {
         List<Networkingresource> listForStudent = new ArrayList<>();
         List<Networkingresource> allPersons = networkingresourcesRepo.findAll();
@@ -59,6 +64,20 @@ public class NetworkingresourceService {
             return null;
         }
         return networkingresourcesRepo.findById(id).get();
+    }
+
+    public Optional<Networkingresource> findOptionalById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return networkingresourcesRepo.findById(id);
+    }
+
+    public Optional<Networkingresource> findByIdAndUid(Long id, String uid) {
+        if (id == null || uid == null) {
+            return Optional.empty();
+        }
+        return networkingresourcesRepo.findByIdAndStudentUid(id, uid);
     }
 
     public void delete(Networkingresource networkingresources) {

--- a/src/main/java/com/coderscampus/cp/service/ResumeService.java
+++ b/src/main/java/com/coderscampus/cp/service/ResumeService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ResumeService {
@@ -43,6 +44,24 @@ public class ResumeService {
         return resumeRepo.findAll();
     }
 
+    public List<Resume> findByUid(String uid) {
+        return resumeRepo.findByStudentUid(uid);
+    }
+
+    public Optional<Resume> findOptionalById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return resumeRepo.findById(id);
+    }
+
+    public Optional<Resume> findByIdAndUid(Long id, String uid) {
+        if (id == null || uid == null) {
+            return Optional.empty();
+        }
+        return resumeRepo.findByIdAndStudentUid(id, uid);
+    }
+
     public Resume findById(Long id) {
         if (id == null) {
             return null;
@@ -55,12 +74,6 @@ public class ResumeService {
     }
 
     public boolean checkIfExists(String uid) {
-        List<Resume> resumes = findAll();
-        for (Resume resume : resumes) {
-            if (resume.getStudent().getUid().equals(uid)) {
-                return true;
-            }
-        }
-        return false;
+        return uid != null && resumeRepo.existsByStudentUid(uid);
     }
 }

--- a/src/main/java/com/coderscampus/cp/web/api/ApiException.java
+++ b/src/main/java/com/coderscampus/cp/web/api/ApiException.java
@@ -1,0 +1,22 @@
+package com.coderscampus.cp.web.api;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class ApiException extends RuntimeException {
+
+    private final Map<String, String> errors;
+
+    public ApiException(String message) {
+        this(message, Collections.emptyMap());
+    }
+
+    public ApiException(String message, Map<String, String> errors) {
+        super(message);
+        this.errors = errors;
+    }
+
+    public Map<String, String> getErrors() {
+        return errors;
+    }
+}

--- a/src/main/java/com/coderscampus/cp/web/api/ApiExceptionHandler.java
+++ b/src/main/java/com/coderscampus/cp/web/api/ApiExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.coderscampus.cp.web.api;
+
+import com.coderscampus.cp.dto.ApiDtos.ApiErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Collections;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiErrorResponse> handleUnauthorized(UnauthorizedException ex) {
+        return error(HttpStatus.UNAUTHORIZED, ex);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ApiErrorResponse> handleForbidden(ForbiddenException ex) {
+        return error(HttpStatus.FORBIDDEN, ex);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleNotFound(ResourceNotFoundException ex) {
+        return error(HttpStatus.NOT_FOUND, ex);
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ApiErrorResponse> handleConflict(ConflictException ex) {
+        return error(HttpStatus.CONFLICT, ex);
+    }
+
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidation(ValidationException ex) {
+        return error(HttpStatus.BAD_REQUEST, ex);
+    }
+
+    private ResponseEntity<ApiErrorResponse> error(HttpStatus status, ApiException ex) {
+        return ResponseEntity.status(status)
+                .body(new ApiErrorResponse(ex.getMessage(), ex.getErrors() == null ? Collections.emptyMap() : ex.getErrors()));
+    }
+}

--- a/src/main/java/com/coderscampus/cp/web/api/ApiSessionService.java
+++ b/src/main/java/com/coderscampus/cp/web/api/ApiSessionService.java
@@ -1,0 +1,34 @@
+package com.coderscampus.cp.web.api;
+
+import com.coderscampus.cp.domain.Student;
+import com.coderscampus.cp.service.StudentService;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class ApiSessionService {
+
+    private final StudentService studentService;
+
+    public ApiSessionService(StudentService studentService) {
+        this.studentService = studentService;
+    }
+
+    public String requireUid(HttpSession session) {
+        String uid = (String) session.getAttribute("uid");
+        if (!StringUtils.hasText(uid)) {
+            throw new UnauthorizedException();
+        }
+        return uid;
+    }
+
+    public Student requireStudent(HttpSession session) {
+        String uid = requireUid(session);
+        Student student = studentService.findStudentByUid(uid);
+        if (student == null) {
+            throw new UnauthorizedException();
+        }
+        return student;
+    }
+}

--- a/src/main/java/com/coderscampus/cp/web/api/BackendRestController.java
+++ b/src/main/java/com/coderscampus/cp/web/api/BackendRestController.java
@@ -1,0 +1,337 @@
+package com.coderscampus.cp.web.api;
+
+import com.coderscampus.cp.domain.Finalproject;
+import com.coderscampus.cp.domain.GitHub;
+import com.coderscampus.cp.domain.LinkedIn;
+import com.coderscampus.cp.domain.Networkingperson;
+import com.coderscampus.cp.domain.Networkingresource;
+import com.coderscampus.cp.domain.Resume;
+import com.coderscampus.cp.domain.Student;
+import com.coderscampus.cp.dto.ApiDtos.FinalProjectRequest;
+import com.coderscampus.cp.dto.ApiDtos.FinalProjectResponse;
+import com.coderscampus.cp.dto.ApiDtos.GitHubProfileRequest;
+import com.coderscampus.cp.dto.ApiDtos.GitHubProfileResponse;
+import com.coderscampus.cp.dto.ApiDtos.LinkedInProfileRequest;
+import com.coderscampus.cp.dto.ApiDtos.LinkedInProfileResponse;
+import com.coderscampus.cp.dto.ApiDtos.NetworkingPersonRequest;
+import com.coderscampus.cp.dto.ApiDtos.NetworkingPersonResponse;
+import com.coderscampus.cp.dto.ApiDtos.NetworkingResourceRequest;
+import com.coderscampus.cp.dto.ApiDtos.NetworkingResourceResponse;
+import com.coderscampus.cp.dto.ApiDtos.ResumeRequest;
+import com.coderscampus.cp.dto.ApiDtos.ResumeResponse;
+import com.coderscampus.cp.dto.StudentDTO;
+import com.coderscampus.cp.service.FinalprojectService;
+import com.coderscampus.cp.service.GitHubService;
+import com.coderscampus.cp.service.LinkedInService;
+import com.coderscampus.cp.service.NetworkingpersonService;
+import com.coderscampus.cp.service.NetworkingresourceService;
+import com.coderscampus.cp.service.ResumeService;
+import com.coderscampus.cp.service.StudentService;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api")
+public class BackendRestController {
+
+    private final ApiSessionService apiSessionService;
+    private final StudentService studentService;
+    private final GitHubService gitHubService;
+    private final LinkedInService linkedInService;
+    private final ResumeService resumeService;
+    private final FinalprojectService finalprojectService;
+    private final NetworkingpersonService networkingpersonService;
+    private final NetworkingresourceService networkingresourceService;
+
+    public BackendRestController(ApiSessionService apiSessionService, StudentService studentService,
+            GitHubService gitHubService, LinkedInService linkedInService, ResumeService resumeService,
+            FinalprojectService finalprojectService, NetworkingpersonService networkingpersonService,
+            NetworkingresourceService networkingresourceService) {
+        this.apiSessionService = apiSessionService;
+        this.studentService = studentService;
+        this.gitHubService = gitHubService;
+        this.linkedInService = linkedInService;
+        this.resumeService = resumeService;
+        this.finalprojectService = finalprojectService;
+        this.networkingpersonService = networkingpersonService;
+        this.networkingresourceService = networkingresourceService;
+    }
+
+    @GetMapping("/students/me")
+    public StudentDTO getCurrentStudent(HttpSession session) {
+        return new StudentDTO(apiSessionService.requireStudent(session));
+    }
+
+    @PatchMapping("/students/me")
+    public StudentDTO updateCurrentStudent(@RequestBody StudentDTO request, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        Student currentStudent = apiSessionService.requireStudent(session);
+        StudentDTO studentDTO = new StudentDTO(currentStudent);
+        if (StringUtils.hasText(request.getName())) {
+            studentDTO.setName(request.getName());
+        }
+        studentDTO.setAssignmentNum(request.getAssignmentNum());
+        studentDTO.setIde(request.getIde());
+        studentDTO.setWillingToMentor(request.getWillingToMentor());
+        studentDTO.setMentee(request.getMentee());
+        return studentService.saveByUid(studentDTO, uid);
+    }
+
+    @GetMapping("/github-profiles")
+    public List<GitHubProfileResponse> getGitHubProfiles(HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return gitHubService.findByUid(uid).stream().map(GitHubProfileResponse::from).toList();
+    }
+
+    @GetMapping("/github-profiles/{id}")
+    public GitHubProfileResponse getGitHubProfile(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return GitHubProfileResponse.from(requireOwned(gitHubService.findByIdAndUid(id, uid), gitHubService.findOptionalById(id)));
+    }
+
+    @PostMapping("/github-profiles")
+    public ResponseEntity<GitHubProfileResponse> createGitHubProfile(@RequestBody GitHubProfileRequest request,
+            HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        if (gitHubService.checkIfExists(uid)) {
+            throw new ConflictException("Current student already has a GitHub profile");
+        }
+        validateUrl("url", request.url(), gitHubService::isValidURL);
+        GitHub gitHub = gitHubService.saveByUid(request.toDomain(null), uid);
+        return ResponseEntity.status(HttpStatus.CREATED).body(GitHubProfileResponse.from(gitHub));
+    }
+
+    @PutMapping("/github-profiles/{id}")
+    public GitHubProfileResponse updateGitHubProfile(@PathVariable Long id, @RequestBody GitHubProfileRequest request,
+            HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        requireOwned(gitHubService.findByIdAndUid(id, uid), gitHubService.findOptionalById(id));
+        validateUrl("url", request.url(), gitHubService::isValidURL);
+        return GitHubProfileResponse.from(gitHubService.saveByUid(request.toDomain(id), uid));
+    }
+
+    @DeleteMapping("/github-profiles/{id}")
+    public ResponseEntity<Void> deleteGitHubProfile(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        gitHubService.delete(requireOwned(gitHubService.findByIdAndUid(id, uid), gitHubService.findOptionalById(id)));
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/linkedin-profiles")
+    public List<LinkedInProfileResponse> getLinkedInProfiles(HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return linkedInService.findByUid(uid).stream().map(LinkedInProfileResponse::from).toList();
+    }
+
+    @GetMapping("/linkedin-profiles/{id}")
+    public LinkedInProfileResponse getLinkedInProfile(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return LinkedInProfileResponse.from(requireOwned(linkedInService.findByIdAndUid(id, uid), linkedInService.findOptionalById(id)));
+    }
+
+    @PostMapping("/linkedin-profiles")
+    public ResponseEntity<LinkedInProfileResponse> createLinkedInProfile(@RequestBody LinkedInProfileRequest request,
+            HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        if (linkedInService.checkIfExists(uid)) {
+            throw new ConflictException("Current student already has a LinkedIn profile");
+        }
+        validateUrl("url", request.url(), linkedInService::isValidURL);
+        LinkedIn linkedIn = linkedInService.saveByUid(request.toDomain(null), uid);
+        return ResponseEntity.status(HttpStatus.CREATED).body(LinkedInProfileResponse.from(linkedIn));
+    }
+
+    @PutMapping("/linkedin-profiles/{id}")
+    public LinkedInProfileResponse updateLinkedInProfile(@PathVariable Long id,
+            @RequestBody LinkedInProfileRequest request, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        requireOwned(linkedInService.findByIdAndUid(id, uid), linkedInService.findOptionalById(id));
+        validateUrl("url", request.url(), linkedInService::isValidURL);
+        return LinkedInProfileResponse.from(linkedInService.saveByUid(request.toDomain(id), uid));
+    }
+
+    @DeleteMapping("/linkedin-profiles/{id}")
+    public ResponseEntity<Void> deleteLinkedInProfile(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        linkedInService.delete(requireOwned(linkedInService.findByIdAndUid(id, uid), linkedInService.findOptionalById(id)));
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/resumes")
+    public List<ResumeResponse> getResumes(HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return resumeService.findByUid(uid).stream().map(ResumeResponse::from).toList();
+    }
+
+    @GetMapping("/resumes/{id}")
+    public ResumeResponse getResume(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return ResumeResponse.from(requireOwned(resumeService.findByIdAndUid(id, uid), resumeService.findOptionalById(id)));
+    }
+
+    @PostMapping("/resumes")
+    public ResponseEntity<ResumeResponse> createResume(@RequestBody ResumeRequest request, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        if (resumeService.checkIfExists(uid)) {
+            throw new ConflictException("Current student already has a resume");
+        }
+        Resume resume = resumeService.saveByUid(request.toDomain(null), uid);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ResumeResponse.from(resume));
+    }
+
+    @PutMapping("/resumes/{id}")
+    public ResumeResponse updateResume(@PathVariable Long id, @RequestBody ResumeRequest request, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        requireOwned(resumeService.findByIdAndUid(id, uid), resumeService.findOptionalById(id));
+        return ResumeResponse.from(resumeService.saveByUid(request.toDomain(id), uid));
+    }
+
+    @DeleteMapping("/resumes/{id}")
+    public ResponseEntity<Void> deleteResume(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        resumeService.delete(requireOwned(resumeService.findByIdAndUid(id, uid), resumeService.findOptionalById(id)));
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/final-projects")
+    public List<FinalProjectResponse> getFinalProjects(HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return finalprojectService.findByUid(uid).stream().map(FinalProjectResponse::from).toList();
+    }
+
+    @GetMapping("/final-projects/{id}")
+    public FinalProjectResponse getFinalProject(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return FinalProjectResponse.from(requireOwned(finalprojectService.findByIdAndUid(id, uid), finalprojectService.findOptionalById(id)));
+    }
+
+    @PostMapping("/final-projects")
+    public ResponseEntity<FinalProjectResponse> createFinalProject(@RequestBody FinalProjectRequest request,
+            HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        validateUrl("proposal", request.proposal(), finalprojectService::isValidURL);
+        Finalproject finalproject = finalprojectService.saveByUid(request.toDomain(null), uid);
+        return ResponseEntity.status(HttpStatus.CREATED).body(FinalProjectResponse.from(finalproject));
+    }
+
+    @PutMapping("/final-projects/{id}")
+    public FinalProjectResponse updateFinalProject(@PathVariable Long id, @RequestBody FinalProjectRequest request,
+            HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        requireOwned(finalprojectService.findByIdAndUid(id, uid), finalprojectService.findOptionalById(id));
+        validateUrl("proposal", request.proposal(), finalprojectService::isValidURL);
+        return FinalProjectResponse.from(finalprojectService.saveByUid(request.toDomain(id), uid));
+    }
+
+    @DeleteMapping("/final-projects/{id}")
+    public ResponseEntity<Void> deleteFinalProject(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        finalprojectService.delete(requireOwned(finalprojectService.findByIdAndUid(id, uid), finalprojectService.findOptionalById(id)));
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/networking-people")
+    public List<NetworkingPersonResponse> getNetworkingPeople(HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return networkingpersonService.findByUid(uid).stream().map(NetworkingPersonResponse::from).toList();
+    }
+
+    @GetMapping("/networking-people/{id}")
+    public NetworkingPersonResponse getNetworkingPerson(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return NetworkingPersonResponse.from(requireOwned(networkingpersonService.findByIdAndUid(id, uid), networkingpersonService.findOptionalById(id)));
+    }
+
+    @PostMapping("/networking-people")
+    public ResponseEntity<NetworkingPersonResponse> createNetworkingPerson(@RequestBody NetworkingPersonRequest request,
+            HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        Networkingperson person = networkingpersonService.saveByUid(request.toDomain(null), uid);
+        return ResponseEntity.status(HttpStatus.CREATED).body(NetworkingPersonResponse.from(person));
+    }
+
+    @PutMapping("/networking-people/{id}")
+    public NetworkingPersonResponse updateNetworkingPerson(@PathVariable Long id,
+            @RequestBody NetworkingPersonRequest request, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        requireOwned(networkingpersonService.findByIdAndUid(id, uid), networkingpersonService.findOptionalById(id));
+        return NetworkingPersonResponse.from(networkingpersonService.saveByUid(request.toDomain(id), uid));
+    }
+
+    @DeleteMapping("/networking-people/{id}")
+    public ResponseEntity<Void> deleteNetworkingPerson(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        networkingpersonService.delete(requireOwned(networkingpersonService.findByIdAndUid(id, uid), networkingpersonService.findOptionalById(id)));
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/networking-resources")
+    public List<NetworkingResourceResponse> getNetworkingResources(HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return networkingresourceService.findByUid(uid).stream().map(NetworkingResourceResponse::from).toList();
+    }
+
+    @GetMapping("/networking-resources/{id}")
+    public NetworkingResourceResponse getNetworkingResource(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        return NetworkingResourceResponse.from(requireOwned(networkingresourceService.findByIdAndUid(id, uid), networkingresourceService.findOptionalById(id)));
+    }
+
+    @PostMapping("/networking-resources")
+    public ResponseEntity<NetworkingResourceResponse> createNetworkingResource(
+            @RequestBody NetworkingResourceRequest request, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        Networkingresource resource = networkingresourceService.saveByUid(request.toDomain(null), uid);
+        return ResponseEntity.status(HttpStatus.CREATED).body(NetworkingResourceResponse.from(resource));
+    }
+
+    @PutMapping("/networking-resources/{id}")
+    public NetworkingResourceResponse updateNetworkingResource(@PathVariable Long id,
+            @RequestBody NetworkingResourceRequest request, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        requireOwned(networkingresourceService.findByIdAndUid(id, uid), networkingresourceService.findOptionalById(id));
+        return NetworkingResourceResponse.from(networkingresourceService.saveByUid(request.toDomain(id), uid));
+    }
+
+    @DeleteMapping("/networking-resources/{id}")
+    public ResponseEntity<Void> deleteNetworkingResource(@PathVariable Long id, HttpSession session) {
+        String uid = apiSessionService.requireUid(session);
+        networkingresourceService.delete(requireOwned(networkingresourceService.findByIdAndUid(id, uid), networkingresourceService.findOptionalById(id)));
+        return ResponseEntity.noContent().build();
+    }
+
+    private <T> T requireOwned(Optional<T> ownedResource, Optional<T> existingResource) {
+        if (ownedResource.isPresent()) {
+            return ownedResource.get();
+        }
+        if (existingResource.isPresent()) {
+            throw new ForbiddenException();
+        }
+        throw new ResourceNotFoundException();
+    }
+
+    private void validateUrl(String field, String value, UrlValidator validator) {
+        if (StringUtils.hasText(value) && !validator.isValid(value)) {
+            throw new ValidationException(Map.of(field, "Invalid URL"));
+        }
+    }
+
+    private interface UrlValidator {
+        boolean isValid(String value);
+    }
+}

--- a/src/main/java/com/coderscampus/cp/web/api/ConflictException.java
+++ b/src/main/java/com/coderscampus/cp/web/api/ConflictException.java
@@ -1,0 +1,8 @@
+package com.coderscampus.cp.web.api;
+
+public class ConflictException extends ApiException {
+
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/coderscampus/cp/web/api/ForbiddenException.java
+++ b/src/main/java/com/coderscampus/cp/web/api/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.coderscampus.cp.web.api;
+
+public class ForbiddenException extends ApiException {
+
+    public ForbiddenException() {
+        super("Forbidden");
+    }
+}

--- a/src/main/java/com/coderscampus/cp/web/api/ResourceNotFoundException.java
+++ b/src/main/java/com/coderscampus/cp/web/api/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.coderscampus.cp.web.api;
+
+public class ResourceNotFoundException extends ApiException {
+
+    public ResourceNotFoundException() {
+        super("Not found");
+    }
+}

--- a/src/main/java/com/coderscampus/cp/web/api/UnauthorizedException.java
+++ b/src/main/java/com/coderscampus/cp/web/api/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package com.coderscampus.cp.web.api;
+
+public class UnauthorizedException extends ApiException {
+
+    public UnauthorizedException() {
+        super("Unauthorized");
+    }
+}

--- a/src/main/java/com/coderscampus/cp/web/api/ValidationException.java
+++ b/src/main/java/com/coderscampus/cp/web/api/ValidationException.java
@@ -1,0 +1,10 @@
+package com.coderscampus.cp.web.api;
+
+import java.util.Map;
+
+public class ValidationException extends ApiException {
+
+    public ValidationException(Map<String, String> errors) {
+        super("Validation failed", errors);
+    }
+}

--- a/src/test/java/com/coderscampus/cp/web/api/BackendRestControllerTest.java
+++ b/src/test/java/com/coderscampus/cp/web/api/BackendRestControllerTest.java
@@ -1,0 +1,177 @@
+package com.coderscampus.cp.web.api;
+
+import com.coderscampus.cp.domain.GitHub;
+import com.coderscampus.cp.domain.Student;
+import com.coderscampus.cp.service.FinalprojectService;
+import com.coderscampus.cp.service.GitHubService;
+import com.coderscampus.cp.service.LinkedInService;
+import com.coderscampus.cp.service.NetworkingpersonService;
+import com.coderscampus.cp.service.NetworkingresourceService;
+import com.coderscampus.cp.service.ResumeService;
+import com.coderscampus.cp.service.StudentService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BackendRestController.class)
+@Import(ApiExceptionHandler.class)
+class BackendRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ApiSessionService apiSessionService;
+
+    @MockBean
+    private StudentService studentService;
+
+    @MockBean
+    private GitHubService gitHubService;
+
+    @MockBean
+    private LinkedInService linkedInService;
+
+    @MockBean
+    private ResumeService resumeService;
+
+    @MockBean
+    private FinalprojectService finalprojectService;
+
+    @MockBean
+    private NetworkingpersonService networkingpersonService;
+
+    @MockBean
+    private NetworkingresourceService networkingresourceService;
+
+    @Test
+    void shouldReturnUnauthorizedWhenSessionHasNoUid() throws Exception {
+        doThrow(new UnauthorizedException()).when(apiSessionService).requireUid(any());
+
+        mockMvc.perform(get("/api/github-profiles"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Unauthorized"))
+                .andExpect(jsonPath("$.errors").isEmpty());
+    }
+
+    @Test
+    void shouldReturnOnlyCurrentUsersGitHubProfiles() throws Exception {
+        String uid = "student-uid";
+        GitHub gitHub = gitHub(1L, 7L, uid);
+        gitHub.setUrl("https://github.com/example");
+        when(apiSessionService.requireUid(any())).thenReturn(uid);
+        when(gitHubService.findByUid(uid)).thenReturn(List.of(gitHub));
+
+        mockMvc.perform(get("/api/github-profiles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].studentId").value(7))
+                .andExpect(jsonPath("$[0].url").value("https://github.com/example"));
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenGitHubProfileBelongsToAnotherUser() throws Exception {
+        String uid = "student-uid";
+        when(apiSessionService.requireUid(any())).thenReturn(uid);
+        when(gitHubService.findByIdAndUid(1L, uid)).thenReturn(Optional.empty());
+        when(gitHubService.findOptionalById(1L)).thenReturn(Optional.of(gitHub(1L, 8L, "other-uid")));
+
+        mockMvc.perform(get("/api/github-profiles/1"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("Forbidden"));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenGitHubProfileDoesNotExist() throws Exception {
+        String uid = "student-uid";
+        when(apiSessionService.requireUid(any())).thenReturn(uid);
+        when(gitHubService.findByIdAndUid(1L, uid)).thenReturn(Optional.empty());
+        when(gitHubService.findOptionalById(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/github-profiles/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Not found"));
+    }
+
+    @Test
+    void shouldReturnConflictWhenCreatingSecondGitHubProfile() throws Exception {
+        String uid = "student-uid";
+        when(apiSessionService.requireUid(any())).thenReturn(uid);
+        when(gitHubService.checkIfExists(uid)).thenReturn(true);
+
+        mockMvc.perform(post("/api/github-profiles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GitHubPayload("https://github.com/example"))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Current student already has a GitHub profile"));
+    }
+
+    @Test
+    void shouldCreateGitHubProfile() throws Exception {
+        String uid = "student-uid";
+        GitHub saved = gitHub(1L, 7L, uid);
+        saved.setUrl("https://github.com/example");
+        when(apiSessionService.requireUid(any())).thenReturn(uid);
+        when(gitHubService.checkIfExists(uid)).thenReturn(false);
+        when(gitHubService.isValidURL("https://github.com/example")).thenReturn(true);
+        when(gitHubService.saveByUid(any(GitHub.class), eq(uid))).thenReturn(saved);
+
+        mockMvc.perform(post("/api/github-profiles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GitHubPayload("https://github.com/example"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.studentId").value(7))
+                .andExpect(jsonPath("$.url").value("https://github.com/example"));
+    }
+
+    @Test
+    void shouldDeleteOwnedGitHubProfile() throws Exception {
+        String uid = "student-uid";
+        GitHub gitHub = gitHub(1L, 7L, uid);
+        when(apiSessionService.requireUid(any())).thenReturn(uid);
+        when(gitHubService.findByIdAndUid(1L, uid)).thenReturn(Optional.of(gitHub));
+        when(gitHubService.findOptionalById(1L)).thenReturn(Optional.of(gitHub));
+
+        mockMvc.perform(delete("/api/github-profiles/1"))
+                .andExpect(status().isNoContent());
+
+        verify(gitHubService).delete(gitHub);
+    }
+
+    private GitHub gitHub(Long id, Long studentId, String uid) {
+        Student student = new Student();
+        ReflectionTestUtils.setField(student, "id", studentId);
+        student.setUid(uid);
+        GitHub gitHub = new GitHub();
+        gitHub.setId(id);
+        gitHub.setStudent(student);
+        return gitHub;
+    }
+
+    private record GitHubPayload(String url) {
+    }
+}


### PR DESCRIPTION
closes #919

We used Codex to plan and implement:
I’d implement ticket #919 as a backend-only REST layer that sits beside the existing Thymeleaf controllers, using docs/md/REST_API_CONTRACT.md as the source of truth.
Implementation Plan
Add shared REST infrastructure:
ApiErrorResponse DTO for:json



{ "message": "...", "errors": {} }


API-specific exceptions like UnauthorizedException, ForbiddenException, ResourceNotFoundException, ConflictException, ValidationException.
@RestControllerAdvice to translate those into 401, 403, 404, 409, and 400.

Add session-auth helper logic:
Read uid from HttpSession.
Return 401 Unauthorized when missing.
Resolve the current Student through StudentService.
Do not allow frontend payloads to submit or override student / uid.

Add REST DTOs instead of exposing JPA entities directly:
GitHubProfileRequest/Response
LinkedInProfileRequest/Response
ResumeRequest/Response
FinalProjectRequest/Response
NetworkingPersonRequest/Response
NetworkingResourceRequest/Response
Reuse or adjust StudentDTO for /api/students/me.

Add REST controllers under /api:
StudentApiControllerGET /api/students/me
PATCH /api/students/me

GitHubProfileApiControllerGET /api/github-profiles
GET /api/github-profiles/{id}
POST /api/github-profiles
PUT /api/github-profiles/{id}
DELETE /api/github-profiles/{id}

Same CRUD pattern for LinkedIn, Resume, Final Project, Networking People, and Networking Resources.

Tighten service/repository access where needed:
Add repository methods like findByIdAndStudent(...) or service methods like findOwnedById(id, uid).
Avoid current REST-unfriendly patterns such as findById(id).get() and findAll() scans for ownership.
Preserve existing Thymeleaf behavior while adding safer methods for REST.

Enforce ownership and one-to-one constraints:
List endpoints return only records owned by the session user.
Single-record reads/updates/deletes check ownership.
GitHub, LinkedIn, and Resume creation should return 409 Conflict if the current student already has one.

Add validation:
Reuse existing URL validation methods where available.
Return 400 Bad Request with field errors for invalid URLs or malformed payloads.
Keep backend as source of truth even if React later adds client validation.

Add MockMvc tests:
Missing session uid returns 401.
Owned records can be read/updated/deleted.
Other users’ records return 403.
Missing records return 404.
Duplicate one-to-one creates return 409.
Invalid URLs return 400.
Successful creates return 201; deletes return 204.

Implementation:
Implemented the backend REST layer for ticket #919.
Added:
/api/students/me
/api/github-profiles
/api/linkedin-profiles
/api/resumes
/api/final-projects
/api/networking-people
/api/networking-resources
Key files:
BackendRestController.java
ApiDtos.java
ApiExceptionHandler.java
ApiSessionService.java
BackendRestControllerTest.java
I also added ownership-aware repository/service methods so the REST layer can return 401, 403, 404, 409, 400, 201, and 204 correctly without exposing nested Student objects in request payloads.
Verification:
mvn -Dtest=BackendRestControllerTest test passes: 7 tests, 0 failures.
Full mvn test could not complete because the local file-backed H2 database is locked: /cp/h2db/cp.mv.db. The main code did compile before the suite failed on that environment issue.